### PR TITLE
Test: voeg testsuite toe voor EduPulse backend

### DIFF
--- a/edupulse/CLAUDE.md
+++ b/edupulse/CLAUDE.md
@@ -53,14 +53,22 @@ Streamlit frontend (frontend/app.py)
         → OpenAI GPT-4.1
 ```
 
-### Backend (`backend/main.py`) — 5 endpoints
+### Backend (`backend/main.py`) — 8 endpoints
 | Endpoint | Input | Purpose |
 |----------|-------|---------|
-| `POST /predict_dropout` | All model features (dict) | Continuous dropout risk score (0–1) |
-| `POST /explain_risk` | Student data + probability + `imputed_columns` | EduPlan: sectie 1 deterministisch HTML; secties 2–4 via GPT-4.1 met alleen SHAP-factoren (geen studentprofiel) |
-| `POST /feature_importance` | Student data | SHAP values per feature (TreeExplainer on regressor) — used for the UI bar chart |
+| `POST /predict_dropout` | All model features (dict) + `use_default_model` | Continuous dropout risk score (0–1) |
+| `POST /explain_risk` | Student data + probability + `imputed_columns` + `use_default_model` | EduPlan: sectie 1 deterministisch HTML; secties 2–4 via GPT-4.1 met alleen SHAP-factoren (geen studentprofiel) |
+| `POST /feature_importance` | Student data + `use_default_model` | SHAP values per feature (TreeExplainer on regressor) — used for the UI bar chart |
 | `POST /summarize` | CSV data string or question | Management summary or Q&A via OpenAI |
 | `POST /map_columns` | Uploaded + required column lists | LLM-based column name mapping for CSV uploads |
+| `POST /train_model` | `data` (list of dicts) + `dropout_column` + optional `rf_parameters` | Train a custom RandomForest on institution data; runs in background thread; saves to `backend/model_custom.joblib` |
+| `GET /train_status` | — | Returns current training state: `idle \| training \| done \| failed` with message |
+| `DELETE /reset_model` | — | Deletes `model_custom.joblib` and resets active model to default |
+
+### Backend (`backend/trainer.py`)
+Standalone training module. `train_model()` runs GridSearchCV over `DEFAULT_PARAM_GRID` on the provided DataFrame, requires ≥ 30 training rows, and saves the best estimator to disk. Called by `/train_model` in a background thread via `threading.Thread`.
+
+**Dual-model architecture:** At startup, `clf_default`/`explainer_default` are always loaded from `backend/model.joblib`. If `backend/model_custom.joblib` exists, `clf`/`explainer` (the active model) point to it; otherwise they alias the default. `use_default_model: bool` on each request selects which pair to use via `_get_model()`.
 
 ### Frontend (`frontend/app.py`) — two screens
 
@@ -140,6 +148,8 @@ Risk levels: **LAAG** (< 35%), **MATIG** (35–65%), **HOOG** (≥ 65%).
 - `/explain_risk` and `/feature_importance` both compute SHAP — this is intentional: the former uses SHAP for the deterministic profile + LLM prompt, the latter serves the UI bar chart
 - CSV uploads use `sep=None, engine="python"` to auto-detect comma, tab, semicolon, etc.
 - `vul_log` (list of imputed column names) is stored in `st.session_state` after upload and passed to `/explain_risk` as `imputed_columns`
+- Training UI state lives in `st.session_state`: `training_status` (`idle|training|done|failed`), `training_message`, and `model_is_custom` (bool). The frontend polls `/train_status` and updates these.
+- `gebruik_demo_data` (bool) and `heeft_dropout_kolom` (bool) track whether the uploaded CSV has a `Dropout` column (required to offer custom model training)
 - All user-facing text and AI responses are in **Dutch**
 - `frontend/ui.py` exists but is currently unused
 - Package manager is **UV** (preferred over pip); cache stored in `./.uv_cache/`

--- a/edupulse/conftest.py
+++ b/edupulse/conftest.py
@@ -1,0 +1,12 @@
+"""Root conftest — patcht OpenAI vóór backend.main wordt geïmporteerd.
+
+Nodig omdat ALL_PROXY een SOCKS-proxy instelt die httpx niet aankan
+zonder het optionele 'socksio'-pakket. De mock voorkomt dat de echte
+OpenAI-client überhaupt wordt aangemaakt tijdens tests.
+"""
+
+from unittest.mock import MagicMock, patch
+
+# Patch openai.OpenAI vóór elke import van backend.main
+_openai_patcher = patch("openai.OpenAI", return_value=MagicMock())
+_openai_patcher.start()

--- a/edupulse/pyproject.toml
+++ b/edupulse/pyproject.toml
@@ -24,3 +24,15 @@ dependencies = [
     "streamlit-extras>=1.2.0",
     "uvicorn>=0.41.0",
 ]
+
+[tool.uv.sources]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/edupulse/tests/conftest.py
+++ b/edupulse/tests/conftest.py
@@ -1,0 +1,38 @@
+"""Gedeelde fixtures voor EduPulse tests.
+
+Voer tests uit vanuit de edupulse/ map:
+    cd edupulse && uv run pytest tests/
+"""
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+
+from backend.main import app, features
+
+
+@pytest.fixture(scope="session")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture(scope="session")
+def demo_student() -> dict:
+    """Eerste rij uit demo-data als volledig geldige student-dict."""
+    df = pd.read_csv("shared/data.csv")
+    NON_FEATURES = {"Dropout", "Naam", "Opleiding", "Klas", "Mentor"}
+    feat_cols = [c for c in df.columns if c not in NON_FEATURES]
+    return df[feat_cols].iloc[0].to_dict()
+
+
+@pytest.fixture
+def mock_openai(monkeypatch) -> MagicMock:
+    """Vervangt de OpenAI-client in backend.main door een mock."""
+    mock_response = MagicMock()
+    mock_response.output_text = "Gemockte LLM-uitvoer"
+    mock_client = MagicMock()
+    mock_client.responses.create.return_value = mock_response
+    import backend.main as main_mod
+    monkeypatch.setattr(main_mod, "client", mock_client)
+    return mock_client

--- a/edupulse/tests/test_backend.py
+++ b/edupulse/tests/test_backend.py
@@ -1,0 +1,309 @@
+"""Tests voor backend/main.py — helperfuncties en FastAPI-endpoints."""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.main as main_mod
+from backend.main import (
+    BINARY_LABELS,
+    FEATURE_LABELS,
+    _build_risicoprofiel_html,
+    _factor_label,
+    _get_model,
+    features,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helperfuncties
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_factor_label_binary_value_1():
+    pos, _ = BINARY_LABELS["StudentGender"]
+    assert _factor_label("StudentGender", 1) == pos
+
+
+def test_factor_label_binary_value_0():
+    _, neg = BINARY_LABELS["StudentGender"]
+    assert _factor_label("StudentGender", 0) == neg
+
+
+def test_factor_label_continuous_uses_feature_label():
+    label = _factor_label("StudentAge", 22)
+    assert FEATURE_LABELS["StudentAge"] in label
+    assert "22" in label
+
+
+def test_factor_label_unknown_key_falls_back_to_key():
+    label = _factor_label("onbekend_kenmerk", 3.5)
+    assert "onbekend_kenmerk" in label
+    assert "3.5" in label
+
+
+def test_build_risicoprofiel_hoog_bevat_risiconiveau():
+    html = _build_risicoprofiel_html(
+        student={"StudentAge": 20, "StudentGender": 1, "absence_unauthorized": 10.0,
+                 "absence_authorized": 0.0, "Aanmel_aantal": 1.0},
+        probability=0.75,
+        risico_niveau="HOOG",
+        urgentie="directe actie vereist (deze week)",
+        top_factors=[("absence_unauthorized", 0.12)],
+        imputed_set=set(),
+        model_name="gpt-4.1",
+    )
+    assert "HOOG" in html
+    assert "75%" in html
+
+
+def test_build_risicoprofiel_matig():
+    html = _build_risicoprofiel_html(
+        student={"StudentAge": 22},
+        probability=0.50,
+        risico_niveau="MATIG",
+        urgentie="actie aanbevolen binnen twee weken",
+        top_factors=[],
+        imputed_set=set(),
+        model_name="gpt-4.1",
+    )
+    assert "MATIG" in html
+
+
+def test_build_risicoprofiel_imputed_field_toont_niet_beschikbaar():
+    html = _build_risicoprofiel_html(
+        student={},
+        probability=0.40,
+        risico_niveau="MATIG",
+        urgentie="actie aanbevolen binnen twee weken",
+        top_factors=[],
+        imputed_set={"StudentAge", "absence_unauthorized"},
+        model_name="gpt-4.1",
+    )
+    assert "niet beschikbaar" in html
+
+
+def test_build_risicoprofiel_data_onvoldoende_toont_waarschuwing():
+    html = _build_risicoprofiel_html(
+        student={},
+        probability=0.30,
+        risico_niveau="LAAG",
+        urgentie="reguliere monitoring volstaat",
+        top_factors=[("StudentAge", 0.001)],
+        imputed_set={"StudentAge"},
+        model_name="gpt-4.1",
+        data_onvoldoende=True,
+    )
+    assert "Datakwaliteit" in html or "onvoldoende" in html.lower()
+
+
+def test_get_model_default_returns_default_model():
+    clf, exp = _get_model(use_default=True)
+    assert clf is main_mod.clf_default
+    assert exp is main_mod.explainer_default
+
+
+def test_get_model_non_default_returns_active_model():
+    clf, exp = _get_model(use_default=False)
+    assert clf is main_mod.clf
+    assert exp is main_mod.explainer
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoints — voorspellingen (geen LLM nodig)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_predict_dropout_probability_in_range(client, demo_student):
+    resp = client.post("/predict_dropout", json={"student": demo_student})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 0.0 <= data["probability"] <= 1.0
+    assert data["prediction"] in (0, 1)
+
+
+def test_predict_dropout_high_absence_higher_probability(client, demo_student):
+    """Student met veel ongeoorloofd verzuim heeft hogere risicoscore dan weinig verzuim."""
+    low = dict(demo_student, absence_unauthorized=0.0)
+    high = dict(demo_student, absence_unauthorized=200.0)
+    prob_low = client.post("/predict_dropout", json={"student": low}).json()["probability"]
+    prob_high = client.post("/predict_dropout", json={"student": high}).json()["probability"]
+    assert prob_high >= prob_low
+
+
+def test_predict_dropout_uses_default_model_flag(client, demo_student):
+    resp = client.post(
+        "/predict_dropout",
+        json={"student": demo_student, "use_default_model": True},
+    )
+    assert resp.status_code == 200
+    assert "probability" in resp.json()
+
+
+def test_feature_importance_returns_all_features(client, demo_student):
+    resp = client.post("/feature_importance", json={"student": demo_student})
+    assert resp.status_code == 200
+    fi = resp.json()["feature_importance"]
+    assert set(fi.keys()) == set(features)
+
+
+def test_feature_importance_values_are_floats(client, demo_student):
+    resp = client.post("/feature_importance", json={"student": demo_student})
+    fi = resp.json()["feature_importance"]
+    assert all(isinstance(v, float) for v in fi.values())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoints — uitleg (LLM gemockt)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_explain_risk_returns_sectie1_html(client, demo_student, mock_openai):
+    payload = {
+        "student": demo_student,
+        "prediction": 1,
+        "probability": 0.70,
+        "imputed_columns": [],
+    }
+    resp = client.post("/explain_risk", json=payload)
+    assert resp.status_code == 200
+    explanation = resp.json()["explanation"]
+    assert "RISICOPROFIEL" in explanation
+    assert "HOOG" in explanation
+
+
+def test_explain_risk_llm_called_when_shap_sufficient(client, demo_student, mock_openai, monkeypatch):
+    """Als SHAP-waarden informatief zijn (max >= 0.01), wordt de LLM aangeroepen."""
+    import numpy as np
+    import backend.main as main_mod
+
+    # Overschrijf de SHAP-explainer zodat er altijd informatieve waarden terugkomen
+    mock_exp = MagicMock()
+    shap_array = np.zeros((1, len(main_mod.features)))
+    # features[0] = Studentnummer zit in SHAP_EXCLUDE; gebruik index 1 (StudentAge)
+    shap_array[0, 1] = 0.5  # één significante factor
+    mock_exp.shap_values.return_value = shap_array
+    monkeypatch.setattr(main_mod, "explainer", mock_exp)
+    monkeypatch.setattr(main_mod, "explainer_default", mock_exp)
+
+    payload = {
+        "student": demo_student,
+        "prediction": 1,
+        "probability": 0.70,
+        "imputed_columns": [],
+    }
+    client.post("/explain_risk", json=payload)
+    assert mock_openai.responses.create.called
+
+
+def test_explain_risk_data_onvoldoende_skips_llm(client, demo_student, mock_openai):
+    """Als alle kolommen geïmputeerd zijn, wordt de LLM niet aangeroepen."""
+    payload = {
+        "student": demo_student,
+        "prediction": 0,
+        "probability": 0.30,
+        "imputed_columns": features,  # alles geïmputeerd
+    }
+    resp = client.post("/explain_risk", json=payload)
+    assert resp.status_code == 200
+    assert not mock_openai.responses.create.called
+    assert "Geen gepersonaliseerd advies" in resp.json()["explanation"]
+
+
+def test_explain_risk_laag_risico(client, demo_student, mock_openai):
+    payload = {
+        "student": demo_student,
+        "prediction": 0,
+        "probability": 0.20,
+        "imputed_columns": [],
+    }
+    resp = client.post("/explain_risk", json=payload)
+    assert resp.status_code == 200
+    assert "LAAG" in resp.json()["explanation"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoints — LLM-afhankelijke endpoints
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_summarize_returns_summary(client, mock_openai):
+    resp = client.post("/summarize", json={"data": "student1,student2"})
+    assert resp.status_code == 200
+    assert "summary" in resp.json()
+    assert resp.json()["summary"] == "Gemockte LLM-uitvoer"
+
+
+def test_map_columns_returns_mapping(client, mock_openai):
+    mock_openai.responses.create.return_value.output_text = (
+        '{"StudentAge": "leeftijd", "absence_unauthorized": "verzuim"}'
+    )
+    resp = client.post(
+        "/map_columns",
+        json={
+            "uploaded_columns": ["leeftijd", "verzuim"],
+            "required_columns": ["StudentAge", "absence_unauthorized"],
+        },
+    )
+    assert resp.status_code == 200
+    mapping = resp.json()["mapping"]
+    assert mapping.get("StudentAge") == "leeftijd"
+
+
+def test_map_columns_invalid_json_returns_empty(client, mock_openai):
+    """Ongeldige LLM-output levert een leeg mapping-object op (geen crash)."""
+    mock_openai.responses.create.return_value.output_text = "geen json hier"
+    resp = client.post(
+        "/map_columns",
+        json={"uploaded_columns": ["x"], "required_columns": ["StudentAge"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["mapping"] == {}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Endpoints — modeltraining en -beheer
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_train_status_returns_status(client):
+    resp = client.get("/train_status")
+    assert resp.status_code == 200
+    assert resp.json()["status"] in ("idle", "training", "done", "failed")
+
+
+def test_reset_model_returns_reset(client):
+    resp = client.delete("/reset_model")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "reset"
+
+
+def test_reset_model_sets_status_idle(client):
+    client.delete("/reset_model")
+    resp = client.get("/train_status")
+    assert resp.json()["status"] == "idle"
+
+
+def test_train_model_endpoint_starts(client, demo_student):
+    """Training start asynchroon; endpoint geeft direct 'started' of 'already_running' terug."""
+    rows = [dict(demo_student, Dropout=float(i % 2)) for i in range(35)]
+    payload = {"data": rows, "dropout_column": "Dropout"}
+    resp = client.post("/train_model", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["status"] in ("started", "already_running")
+
+    try:
+        # Wacht max 60 seconden tot training klaar is
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            status_resp = client.get("/train_status")
+            if status_resp.json()["status"] in ("done", "failed"):
+                break
+            time.sleep(1)
+        else:
+            pytest.fail("Training voltooide niet binnen 60 seconden")
+    finally:
+        # Altijd terugzetten naar standaardmodel, ook bij testfout
+        client.delete("/reset_model")

--- a/edupulse/tests/test_trainer.py
+++ b/edupulse/tests/test_trainer.py
@@ -1,0 +1,108 @@
+"""Tests voor backend/trainer.py."""
+
+import os
+import tempfile
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.ensemble import RandomForestRegressor
+
+from backend.main import features
+from backend import trainer
+
+
+def _make_df(n: int, seed: int = 0) -> pd.DataFrame:
+    """Genereer een synthetisch DataFrame met alle model-features en een Dropout-kolom."""
+    rng = np.random.default_rng(seed)
+    df = pd.DataFrame(
+        rng.random((n, len(features))), columns=features
+    )
+    df["Dropout"] = rng.integers(0, 2, size=n).astype(float)
+    return df
+
+
+def test_train_model_saves_file():
+    df = _make_df(50)
+    with tempfile.NamedTemporaryFile(suffix=".joblib", delete=False) as f:
+        path = f.name
+    try:
+        trainer.train_model(df, "Dropout", features, path)
+        assert os.path.exists(path)
+    finally:
+        os.unlink(path)
+
+
+def test_train_model_returns_random_forest():
+    df = _make_df(50)
+    with tempfile.NamedTemporaryFile(suffix=".joblib", delete=False) as f:
+        path = f.name
+    try:
+        model = trainer.train_model(df, "Dropout", features, path)
+        assert isinstance(model, RandomForestRegressor)
+    finally:
+        os.unlink(path)
+
+
+def test_train_model_predictions_in_range():
+    df = _make_df(60)
+    with tempfile.NamedTemporaryFile(suffix=".joblib", delete=False) as f:
+        path = f.name
+    try:
+        model = trainer.train_model(df, "Dropout", features, path)
+        X = df[features].values[:5]
+        preds = model.predict(X)
+        assert all(0.0 <= p <= 1.0 for p in preds)
+    finally:
+        os.unlink(path)
+
+
+def test_train_model_too_few_rows_raises():
+    df = _make_df(10)
+    with tempfile.NamedTemporaryFile(suffix=".joblib", delete=False) as f:
+        path = f.name
+    try:
+        with pytest.raises(ValueError, match="Te weinig trainingsdata"):
+            trainer.train_model(df, "Dropout", features, path)
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_train_model_exactly_30_rows_succeeds():
+    df = _make_df(30)
+    with tempfile.NamedTemporaryFile(suffix=".joblib", delete=False) as f:
+        path = f.name
+    try:
+        model = trainer.train_model(df, "Dropout", features, path)
+        assert model is not None
+    finally:
+        os.unlink(path)
+
+
+def test_train_model_drops_nan_rows():
+    """NaN-rijen worden voor training verwijderd; te weinig over → ValueError."""
+    df = _make_df(50)
+    # Maak Dropout NaN voor alle rijen behalve 5
+    df.loc[5:, "Dropout"] = float("nan")
+    with tempfile.NamedTemporaryFile(suffix=".joblib", delete=False) as f:
+        path = f.name
+    try:
+        with pytest.raises(ValueError, match="Te weinig trainingsdata"):
+            trainer.train_model(df, "Dropout", features, path)
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def test_train_model_custom_param_grid():
+    """Aangepast param_grid wordt geaccepteerd zonder fout."""
+    df = _make_df(50)
+    minimal_grid = {"n_estimators": [10], "max_depth": [3], "min_samples_split": [2], "max_features": ["sqrt"]}
+    with tempfile.NamedTemporaryFile(suffix=".joblib", delete=False) as f:
+        path = f.name
+    try:
+        model = trainer.train_model(df, "Dropout", features, path, param_grid=minimal_grid)
+        assert isinstance(model, RandomForestRegressor)
+    finally:
+        os.unlink(path)

--- a/edupulse/uv.lock
+++ b/edupulse/uv.lock
@@ -277,6 +277,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -811,6 +820,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -941,6 +959,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240, upload-time = "2024-05-10T15:36:21.153Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403, upload-time = "2024-05-10T15:36:17.36Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1291,13 +1334,21 @@ dependencies = [
     { name = "uvicorn" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.135.1" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "openai", specifier = ">=2.26.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "plotly", specifier = ">=6.6.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "python-docx", specifier = ">=1.2.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
@@ -1306,6 +1357,7 @@ requires-dist = [
     { name = "streamlit-extras", specifier = ">=1.2.0" },
     { name = "uvicorn", specifier = ">=0.41.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "streamlit-extras"


### PR DESCRIPTION
## Summary
- Adds 33 pytest tests covering \`backend/trainer.py\` and all 8 FastAPI endpoints
- Adds \`pytest\` and \`httpx\` as dev dependencies; configures testpath and pythonpath in \`pyproject.toml\`
- Root \`conftest.py\` patches \`openai.OpenAI\` at import time so tests run without API key or proxy

## Test plan
- \`cd edupulse && uv run pytest tests/ -v\`
- All 33 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)