### PR TITLE
chore: ruff import-opschoning in overige edupulse-bestanden

### DIFF
--- a/edupulse/backend/trainer.py
+++ b/edupulse/backend/trainer.py
@@ -4,9 +4,9 @@ Trainingslogica voor het instellingsspecifieke Random Forest-model.
 Gebaseerd op de aanpak van cedanl/Uitnodigingsregel.
 """
 
-import joblib
 from pathlib import Path
 
+import joblib
 import pandas as pd
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import GridSearchCV

--- a/edupulse/main.py
+++ b/edupulse/main.py
@@ -11,11 +11,12 @@
 # Original Authors: Ed. de Feber, Edwin Lieftink
 # -----------------------------------------------------------------------------
 
-import os
-import sys
 import argparse
 import logging
-from typing import List, Dict, Any
+import os
+import sys
+from typing import Any
+
 from anthropic import Anthropic  # type: ignore
 from pydantic import BaseModel  # type: ignore
 
@@ -34,14 +35,14 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 class Tool(BaseModel):
     name: str
     description: str
-    input_schema: Dict[str, Any]
+    input_schema: dict[str, Any]
 
 
 class AIAgent:
     def __init__(self, api_key: str):
         self.client = Anthropic(api_key=api_key)
-        self.messages: List[Dict[str, Any]] = []
-        self.tools: List[Tool] = []
+        self.messages: list[dict[str, Any]] = []
+        self.tools: list[Tool] = []
         self._setup_tools()
 
     def _setup_tools(self):
@@ -98,7 +99,7 @@ class AIAgent:
             ),
         ]
 
-    def _execute_tool(self, tool_name: str, tool_input: Dict[str, Any]) -> str:
+    def _execute_tool(self, tool_name: str, tool_input: dict[str, Any]) -> str:
         logging.info(f"Executing tool: {tool_name} with input: {tool_input}")
         try:
             if tool_name == "read_file":
@@ -119,7 +120,7 @@ class AIAgent:
 
     def _read_file(self, path: str) -> str:
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(path, encoding="utf-8") as f:
                 content = f.read()
             return f"File contents of {path}:\n{content}"
         except FileNotFoundError:
@@ -150,7 +151,7 @@ class AIAgent:
     def _edit_file(self, path: str, old_text: str, new_text: str) -> str:
         try:
             if os.path.exists(path) and old_text:
-                with open(path, "r", encoding="utf-8") as f:
+                with open(path, encoding="utf-8") as f:
                     content = f.read()
 
                 if old_text not in content:

--- a/edupulse/shared/data_prep.py
+++ b/edupulse/shared/data_prep.py
@@ -7,10 +7,11 @@ Uitvoeren vanuit de projectroot:
     python shared/data_prep.py
 """
 
-import urllib.request
-import pandas as pd
-import numpy as np
 import random
+import urllib.request
+
+import numpy as np
+import pandas as pd
 
 random.seed(42)
 np.random.seed(42)
@@ -68,5 +69,5 @@ df["Mentor"] = [random.choice(mentoren) for _ in range(n)]
 
 df.to_csv("shared/data.csv", index=False)
 print(f"\nshared/data.csv opgeslagen ({n} studenten).")
-print(f"backend/model.joblib gedownload.")
+print("backend/model.joblib gedownload.")
 print(f"\nKolommen in data.csv: {list(df.columns)}")

--- a/edupulse/tests/conftest.py
+++ b/edupulse/tests/conftest.py
@@ -4,12 +4,13 @@ Voer tests uit vanuit de edupulse/ map:
     cd edupulse && uv run pytest tests/
 """
 
+from unittest.mock import MagicMock
+
 import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import MagicMock
 
-from backend.main import app, features
+from backend.main import app
 
 
 @pytest.fixture(scope="session")

--- a/edupulse/tests/test_backend.py
+++ b/edupulse/tests/test_backend.py
@@ -4,7 +4,6 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi.testclient import TestClient
 
 import backend.main as main_mod
 from backend.main import (
@@ -15,7 +14,6 @@ from backend.main import (
     _get_model,
     features,
 )
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helperfuncties
@@ -177,6 +175,7 @@ def test_explain_risk_returns_sectie1_html(client, demo_student, mock_openai):
 def test_explain_risk_llm_called_when_shap_sufficient(client, demo_student, mock_openai, monkeypatch):
     """Als SHAP-waarden informatief zijn (max >= 0.01), wordt de LLM aangeroepen."""
     import numpy as np
+
     import backend.main as main_mod
 
     # Overschrijf de SHAP-explainer zodat er altijd informatieve waarden terugkomen

--- a/edupulse/tests/test_trainer.py
+++ b/edupulse/tests/test_trainer.py
@@ -8,8 +8,8 @@ import pandas as pd
 import pytest
 from sklearn.ensemble import RandomForestRegressor
 
-from backend.main import features
 from backend import trainer
+from backend.main import features
 
 
 def _make_df(n: int, seed: int = 0) -> pd.DataFrame:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,6 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "ruff>=0.15.10",
     "streamlit>=1.46.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -440,6 +440,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -491,11 +516,15 @@ name = "streamlit-app-template"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "ruff" },
     { name = "streamlit" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "streamlit", specifier = ">=1.46.0" }]
+requires-dist = [
+    { name = "ruff", specifier = ">=0.15.10" },
+    { name = "streamlit", specifier = ">=1.46.0" },
+]
 
 [[package]]
 name = "tenacity"


### PR DESCRIPTION
## Summary

- Importvolgorde herschikt naar PEP8 (stdlib voor third-party) in `trainer.py`, `main.py`, `data_prep.py` en alle testbestanden
- `Dict`/`List` uit `typing` vervangen door ingebouwde `dict`/`list` (Python 3.10+)
- Overbodige imports verwijderd (`TestClient` in `test_backend.py`, `features` in `conftest.py`)
- Onnodige `"r"` modus verwijderd uit `open()`-aanroepen (standaard al read)
- f-string zonder interpolatie gecorrigeerd naar gewone string (`data_prep.py`)
- `ruff>=0.15.10` toegevoegd aan root `pyproject.toml`

## Test plan

- [x] `uv run ruff check` — geen fouten
- [x] `uv run pytest tests/ -q` — 33/33 groen
- [x] Geen functionele wijzigingen

🤖 Generated with [Claude Code](https://claude.com/claude-code)