### PR TITLE
chore: stijlfix src/ en edupulse/main.py — pathlib, moderne types, ruff-config

### DIFF
--- a/edupulse/main.py
+++ b/edupulse/main.py
@@ -15,6 +15,7 @@ import argparse
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import Any
 
 from anthropic import Anthropic  # type: ignore
@@ -130,16 +131,16 @@ class AIAgent:
 
     def _list_files(self, path: str) -> str:
         try:
-            if not os.path.exists(path):
+            p = Path(path)
+            if not p.exists():
                 return f"Path not found: {path}"
 
             items = []
-            for item in sorted(os.listdir(path)):
-                item_path = os.path.join(path, item)
-                if os.path.isdir(item_path):
-                    items.append(f"[DIR]  {item}/")
+            for entry in sorted(p.iterdir(), key=lambda x: x.name):
+                if entry.is_dir():
+                    items.append(f"[DIR]  {entry.name}/")
                 else:
-                    items.append(f"[FILE] {item}")
+                    items.append(f"[FILE] {entry.name}")
 
             if not items:
                 return f"Empty directory: {path}"
@@ -150,28 +151,18 @@ class AIAgent:
 
     def _edit_file(self, path: str, old_text: str, new_text: str) -> str:
         try:
-            if os.path.exists(path) and old_text:
-                with open(path, encoding="utf-8") as f:
-                    content = f.read()
+            p = Path(path)
+            if p.exists() and old_text:
+                content = p.read_text(encoding="utf-8")
 
                 if old_text not in content:
                     return f"Text not found in file: {old_text}"
 
-                content = content.replace(old_text, new_text)
-
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(content)
-
+                p.write_text(content.replace(old_text, new_text), encoding="utf-8")
                 return f"Successfully edited {path}"
             else:
-                # Only create directory if path contains subdirectories
-                dir_name = os.path.dirname(path)
-                if dir_name:
-                    os.makedirs(dir_name, exist_ok=True)
-
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(new_text)
-
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(new_text, encoding="utf-8")
                 return f"Successfully created {path}"
         except Exception as e:
             return f"Error editing file: {str(e)}"
@@ -203,9 +194,7 @@ class AIAgent:
 
                 for content in response.content:
                     if content.type == "text":
-                        assistant_message["content"].append(
-                            {"type": "text", "text": content.text}
-                        )
+                        assistant_message["content"].append({"type": "text", "text": content.text})
                     elif content.type == "tool_use":
                         assistant_message["content"].append(
                             {
@@ -222,9 +211,7 @@ class AIAgent:
                 for content in response.content:
                     if content.type == "tool_use":
                         result = self._execute_tool(content.name, content.input)
-                        logging.info(
-                            f"Tool result: {result[:500]}..."
-                        )  # Log first 500 chars
+                        logging.info(f"Tool result: {result[:500]}...")  # Log first 500 chars
                         tool_results.append(
                             {
                                 "type": "tool_result",
@@ -246,16 +233,12 @@ def main():
     parser = argparse.ArgumentParser(
         description="AI Code Assistant - A conversational AI agent with file editing capabilities"
     )
-    parser.add_argument(
-        "--api-key", help="Anthropic API key (or set ANTHROPIC_API_KEY env var)"
-    )
+    parser.add_argument("--api-key", help="Anthropic API key (or set ANTHROPIC_API_KEY env var)")
     args = parser.parse_args()
 
     api_key = args.api_key or os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
-        print(
-            "Error: Please provide an API key via --api-key or ANTHROPIC_API_KEY environment variable"
-        )
+        print("Error: Please provide an API key via --api-key or ANTHROPIC_API_KEY environment variable")
         sys.exit(1)
 
     agent = AIAgent(api_key)
@@ -292,5 +275,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,10 @@ dependencies = [
     "ruff>=0.15.10",
     "streamlit>=1.46.0",
 ]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+ignore = ["E501"]

--- a/src/backend/example_sales.py
+++ b/src/backend/example_sales.py
@@ -1,82 +1,72 @@
 import json
-import os
-from datetime import datetime, timedelta
 import random
+from datetime import datetime, timedelta
+from pathlib import Path
 
-SALES_FILE = "data/sales.json"
+SALES_FILE = Path("data/sales.json")
+
 
 def generate_sample_sales():
-    """Generate sample sales data if file doesn't exist"""
+    """Generate sample sales data if file doesn't exist."""
     categories = ["Electronics", "Clothing", "Books", "Home", "Sports"]
     sales = []
-    
-    # Generate 6 months of sample data
+
     start_date = datetime.now() - timedelta(days=180)
-    
+
     for i in range(100):
         date = start_date + timedelta(days=random.randint(0, 180))
         sale = {
-            'id': i + 1,
-            'date': date.strftime('%Y-%m-%d'),
-            'amount': round(random.uniform(50, 1000), 2),
-            'category': random.choice(categories),
-            'customer': f"Customer_{random.randint(1, 50)}"
+            "id": i + 1,
+            "date": date.strftime("%Y-%m-%d"),
+            "amount": round(random.uniform(50, 1000), 2),
+            "category": random.choice(categories),
+            "customer": f"Customer_{random.randint(1, 50)}",
         }
         sales.append(sale)
-    
+
     return sales
 
+
 def get_sales_data():
-    """Load or generate sales data"""
-    if not os.path.exists(SALES_FILE):
-        os.makedirs(os.path.dirname(SALES_FILE), exist_ok=True)
+    """Load or generate sales data."""
+    if not SALES_FILE.exists():
+        SALES_FILE.parent.mkdir(parents=True, exist_ok=True)
         sales = generate_sample_sales()
-        with open(SALES_FILE, 'w') as f:
-            json.dump(sales, f, indent=2)
+        SALES_FILE.write_text(json.dumps(sales, indent=2), encoding="utf-8")
         return sales
-    
-    with open(SALES_FILE, 'r') as f:
-        return json.load(f)
+
+    return json.loads(SALES_FILE.read_text(encoding="utf-8"))
+
 
 def calculate_sales_metrics(sales_data):
-    """Calculate key sales metrics"""
+    """Calculate key sales metrics."""
     if not sales_data:
-        return {'total': 0, 'average': 0, 'best_month': 'N/A', 'growth': 0}
-    
-    total = sum(sale['amount'] for sale in sales_data)
+        return {"total": 0, "average": 0, "best_month": "N/A", "growth": 0}
+
+    total = sum(sale["amount"] for sale in sales_data)
     average = total / len(sales_data)
-    
-    # Find best month
-    monthly_totals = {}
+
+    monthly_totals: dict[str, float] = {}
     for sale in sales_data:
-        month = sale['date'][:7]  # YYYY-MM
-        if month not in monthly_totals:
-            monthly_totals[month] = 0
-        monthly_totals[month] += sale['amount']
-    
-    best_month = max(monthly_totals, key=monthly_totals.get) if monthly_totals else 'N/A'
-    
-    # Calculate simple growth (last month vs first month)
+        month = sale["date"][:7]
+        monthly_totals[month] = monthly_totals.get(month, 0) + sale["amount"]
+
+    best_month = max(monthly_totals, key=monthly_totals.get) if monthly_totals else "N/A"
+
     months = sorted(monthly_totals.keys())
     if len(months) >= 2:
         growth = ((monthly_totals[months[-1]] - monthly_totals[months[0]]) / monthly_totals[months[0]]) * 100
     else:
         growth = 0
-    
-    return {
-        'total': total,
-        'average': average,
-        'best_month': best_month,
-        'growth': growth
-    }
+
+    return {"total": total, "average": average, "best_month": best_month, "growth": growth}
+
 
 def get_monthly_sales(sales_data):
-    """Get monthly sales data for charting"""
-    monthly_data = {}
+    """Get monthly sales data for charting."""
+    monthly_data: dict[str, float] = {}
     for sale in sales_data:
-        month = sale['date'][:7]  # YYYY-MM
-        if month not in monthly_data:
-            monthly_data[month] = 0
-        monthly_data[month] += sale['amount']
-    
+        month = sale["date"][:7]
+        monthly_data[month] = monthly_data.get(month, 0) + sale["amount"]
+
     return monthly_data

--- a/src/backend/example_task.py
+++ b/src/backend/example_task.py
@@ -1,55 +1,59 @@
 import json
-import os
 from datetime import datetime
+from pathlib import Path
 
-TASK_FILE = "data/tasks.json"
+TASK_FILE = Path("data/tasks.json")
+
 
 def load_tasks():
-    """Load tasks from JSON file"""
-    if not os.path.exists(TASK_FILE):
-        os.makedirs(os.path.dirname(TASK_FILE), exist_ok=True)
+    """Load tasks from JSON file."""
+    if not TASK_FILE.exists():
+        TASK_FILE.parent.mkdir(parents=True, exist_ok=True)
         return []
-    
+
     try:
-        with open(TASK_FILE, 'r') as f:
-            return json.load(f)
-    except:
+        return json.loads(TASK_FILE.read_text(encoding="utf-8"))
+    except Exception:
         return []
+
 
 def save_tasks(tasks):
-    """Save tasks to JSON file"""
-    with open(TASK_FILE, 'w') as f:
-        json.dump(tasks, f, indent=2)
+    """Save tasks to JSON file."""
+    TASK_FILE.write_text(json.dumps(tasks, indent=2), encoding="utf-8")
+
 
 def add_task(title, description, priority):
-    """Add a new task"""
+    """Add a new task."""
     tasks = load_tasks()
     new_task = {
-        'id': len(tasks) + 1,
-        'title': title,
-        'description': description,
-        'priority': priority,
-        'completed': False,
-        'created_at': datetime.now().isoformat()
+        "id": len(tasks) + 1,
+        "title": title,
+        "description": description,
+        "priority": priority,
+        "completed": False,
+        "created_at": datetime.now().isoformat(),
     }
     tasks.append(new_task)
     save_tasks(tasks)
 
+
 def get_tasks():
-    """Get all tasks"""
+    """Get all tasks."""
     return load_tasks()
 
+
 def update_task_status(task_id, completed):
-    """Update task completion status"""
+    """Update task completion status."""
     tasks = load_tasks()
     for task in tasks:
-        if task['id'] == task_id:
-            task['completed'] = completed
+        if task["id"] == task_id:
+            task["completed"] = completed
             break
     save_tasks(tasks)
 
+
 def delete_task(task_id):
-    """Delete a task by ID"""
+    """Delete a task by ID."""
     tasks = load_tasks()
-    tasks = [t for t in tasks if t['id'] != task_id]
+    tasks = [t for t in tasks if t["id"] != task_id]
     save_tasks(tasks)

--- a/src/frontend/Modules/example_Sales.py
+++ b/src/frontend/Modules/example_Sales.py
@@ -1,5 +1,7 @@
 import streamlit as st
-from backend.example_sales import get_sales_data, calculate_sales_metrics, get_monthly_sales
+
+from backend.example_sales import calculate_sales_metrics, get_monthly_sales, get_sales_data
+
 # ---------------------------------------
 # PAGE CONFIGURATION
 # ---------------------------------------
@@ -23,7 +25,7 @@ with col1:
 with col2:
     st.metric("Average Sale", f"${metrics['average']:.2f}")
 with col3:
-    st.metric("Best Month", metrics['best_month'])
+    st.metric("Best Month", metrics["best_month"])
 with col4:
     st.metric("Growth", f"{metrics['growth']:.1f}%")
 
@@ -36,10 +38,10 @@ st.line_chart(monthly_data)
 st.subheader("Sales by Category")
 category_data = {}
 for sale in sales_data:
-    category = sale['category']
+    category = sale["category"]
     if category not in category_data:
         category_data[category] = 0
-    category_data[category] += sale['amount']
+    category_data[category] += sale["amount"]
 
 st.bar_chart(category_data)
 

--- a/src/frontend/Modules/example_Task.py
+++ b/src/frontend/Modules/example_Task.py
@@ -1,5 +1,6 @@
 import streamlit as st
-from backend.example_task import add_task, get_tasks, update_task_status, delete_task
+
+from backend.example_task import add_task, delete_task, get_tasks, update_task_status
 
 # ---------------------------------------
 # PAGE CONFIGURATION
@@ -19,7 +20,7 @@ with st.form("add_task"):
     title = st.text_input("Task Title")
     description = st.text_area("Description")
     priority = st.selectbox("Priority", ["Low", "Medium", "High"])
-    
+
     if st.form_submit_button("Add Task"):
         if title:
             add_task(title, description, priority)
@@ -37,27 +38,27 @@ if not tasks:
 for task in tasks:
     with st.container():
         col1, col2, col3, col4 = st.columns([3, 1, 1, 1])
-        
+
         with col1:
-            if task['completed']:
+            if task["completed"]:
                 st.write(f"~~{task['title']}~~ ✅")
             else:
                 st.write(f"**{task['title']}**")
-            if task['description']:
+            if task["description"]:
                 st.write(f"*{task['description']}*")
-        
+
         with col2:
             color = {"High": "🔴", "Medium": "🟡", "Low": "🟢"}
-            st.write(color.get(task['priority'], '') + task['priority'])
-        
+            st.write(color.get(task["priority"], "") + task["priority"])
+
         with col3:
             if st.button("Toggle", key=f"toggle_{task['id']}"):
-                update_task_status(task['id'], not task['completed'])
+                update_task_status(task["id"], not task["completed"])
                 st.rerun()
-        
+
         with col4:
             if st.button("Delete", key=f"del_{task['id']}"):
-                delete_task(task['id'])
+                delete_task(task["id"])
                 st.rerun()
-        
+
         st.divider()

--- a/src/main.py
+++ b/src/main.py
@@ -11,11 +11,13 @@
 # Original Authors: Ed. de Feber, Edwin Lieftink
 # -----------------------------------------------------------------------------
 
-import os
-import sys
 import argparse
 import logging
-from typing import List, Dict, Any
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
 from anthropic import Anthropic  # type: ignore
 from pydantic import BaseModel  # type: ignore
 
@@ -34,14 +36,14 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 class Tool(BaseModel):
     name: str
     description: str
-    input_schema: Dict[str, Any]
+    input_schema: dict[str, Any]
 
 
 class AIAgent:
     def __init__(self, api_key: str):
         self.client = Anthropic(api_key=api_key)
-        self.messages: List[Dict[str, Any]] = []
-        self.tools: List[Tool] = []
+        self.messages: list[dict[str, Any]] = []
+        self.tools: list[Tool] = []
         self._setup_tools()
 
     def _setup_tools(self):
@@ -98,7 +100,7 @@ class AIAgent:
             ),
         ]
 
-    def _execute_tool(self, tool_name: str, tool_input: Dict[str, Any]) -> str:
+    def _execute_tool(self, tool_name: str, tool_input: dict[str, Any]) -> str:
         logging.info(f"Executing tool: {tool_name} with input: {tool_input}")
         try:
             if tool_name == "read_file":
@@ -119,8 +121,7 @@ class AIAgent:
 
     def _read_file(self, path: str) -> str:
         try:
-            with open(path, "r", encoding="utf-8") as f:
-                content = f.read()
+            content = Path(path).read_text(encoding="utf-8")
             return f"File contents of {path}:\n{content}"
         except FileNotFoundError:
             return f"File not found: {path}"
@@ -129,16 +130,16 @@ class AIAgent:
 
     def _list_files(self, path: str) -> str:
         try:
-            if not os.path.exists(path):
+            p = Path(path)
+            if not p.exists():
                 return f"Path not found: {path}"
 
             items = []
-            for item in sorted(os.listdir(path)):
-                item_path = os.path.join(path, item)
-                if os.path.isdir(item_path):
-                    items.append(f"[DIR]  {item}/")
+            for entry in sorted(p.iterdir(), key=lambda x: x.name):
+                if entry.is_dir():
+                    items.append(f"[DIR]  {entry.name}/")
                 else:
-                    items.append(f"[FILE] {item}")
+                    items.append(f"[FILE] {entry.name}")
 
             if not items:
                 return f"Empty directory: {path}"
@@ -149,28 +150,18 @@ class AIAgent:
 
     def _edit_file(self, path: str, old_text: str, new_text: str) -> str:
         try:
-            if os.path.exists(path) and old_text:
-                with open(path, "r", encoding="utf-8") as f:
-                    content = f.read()
+            p = Path(path)
+            if p.exists() and old_text:
+                content = p.read_text(encoding="utf-8")
 
                 if old_text not in content:
                     return f"Text not found in file: {old_text}"
 
-                content = content.replace(old_text, new_text)
-
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(content)
-
+                p.write_text(content.replace(old_text, new_text), encoding="utf-8")
                 return f"Successfully edited {path}"
             else:
-                # Only create directory if path contains subdirectories
-                dir_name = os.path.dirname(path)
-                if dir_name:
-                    os.makedirs(dir_name, exist_ok=True)
-
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(new_text)
-
+                p.parent.mkdir(parents=True, exist_ok=True)
+                p.write_text(new_text, encoding="utf-8")
                 return f"Successfully created {path}"
         except Exception as e:
             return f"Error editing file: {str(e)}"
@@ -202,9 +193,7 @@ class AIAgent:
 
                 for content in response.content:
                     if content.type == "text":
-                        assistant_message["content"].append(
-                            {"type": "text", "text": content.text}
-                        )
+                        assistant_message["content"].append({"type": "text", "text": content.text})
                     elif content.type == "tool_use":
                         assistant_message["content"].append(
                             {
@@ -221,9 +210,7 @@ class AIAgent:
                 for content in response.content:
                     if content.type == "tool_use":
                         result = self._execute_tool(content.name, content.input)
-                        logging.info(
-                            f"Tool result: {result[:500]}..."
-                        )  # Log first 500 chars
+                        logging.info(f"Tool result: {result[:500]}...")
                         tool_results.append(
                             {
                                 "type": "tool_result",
@@ -245,16 +232,12 @@ def main():
     parser = argparse.ArgumentParser(
         description="AI Code Assistant - A conversational AI agent with file editing capabilities"
     )
-    parser.add_argument(
-        "--api-key", help="Anthropic API key (or set ANTHROPIC_API_KEY env var)"
-    )
+    parser.add_argument("--api-key", help="Anthropic API key (or set ANTHROPIC_API_KEY env var)")
     args = parser.parse_args()
 
     api_key = args.api_key or os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
-        print(
-            "Error: Please provide an API key via --api-key or ANTHROPIC_API_KEY environment variable"
-        )
+        print("Error: Please provide an API key via --api-key or ANTHROPIC_API_KEY environment variable")
         sys.exit(1)
 
     agent = AIAgent(api_key)
@@ -291,5 +274,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-


### PR DESCRIPTION
## Summary

- `os.path.*` vervangen door `pathlib.Path` in `src/main.py`, `src/backend/example_*.py` en `edupulse/main.py`
- `Dict`/`List` uit `typing` vervangen door ingebouwde `dict`/`list` in `src/main.py`
- Bare `except:` gecorrigeerd naar `except Exception:` in `src/backend/example_task.py` (was ruff E722)
- Onnodige `"r"` modus verwijderd uit `open()` in `src/main.py`
- Import-volgorde (I001) gefixed in `src/frontend/Modules/example_*.py`
- `[tool.ruff]` config toegevoegd aan root `pyproject.toml`
- `ruff format` uitgevoerd op alle bestanden in `src/` en `edupulse/`

## Test plan

- [x] `uv run ruff check src/` — geen fouten
- [x] `uv run ruff format --check src/` — geen wijzigingen
- [x] `uv run ruff check edupulse/` — geen fouten  
- [x] `uv run ruff format --check edupulse/` — geen wijzigingen
- [x] Geen functionele wijzigingen

🤖 Generated with [Claude Code](https://claude.com/claude-code)