### PR TITLE
eduplan: migrate backend LLM from OpenAI to Anthropic Sonnet 4.6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Interactive CLI with file tools: `read_file`, `list_files`, `edit_file`. Require
 ## EduPlan Sub-Project
 
 See `eduplan/CLAUDE.md` for full details on the dropout-risk app. Key points:
-- Env vars: `OPENAI_API_KEY` (backend GPT-4.1 via Responses API), `ANTHROPIC_API_KEY` (standalone agent CLI only)
+- Env vars: `ANTHROPIC_API_KEY` (backend Sonnet 4.6 via Messages API; also used by the standalone agent CLI)
 - Both the FastAPI backend (port 8000) and Streamlit frontend (port 8502) must run simultaneously
 - SVG branding assets live in `eduplan/frontend/static/`
 - Training uses **[student-signal](https://github.com/cedanl/student-signal)** (KNN-imputation + GridSearchCV); feature lists are stored as JSON next to each model file

--- a/eduplan/1_start_fastapi.sh
+++ b/eduplan/1_start_fastapi.sh
@@ -65,6 +65,11 @@ echo
 echo "Druk op Ctrl+C om de app te stoppen."
 echo
 
+# Laad .env zodat ANTHROPIC_API_KEY (en andere env vars) beschikbaar zijn voor de backend
+set -a
+[ -f .env ] && source .env
+set +a
+
 uvicorn --host "127.0.0.1" --port 8000 backend.main:app --reload
 RESULT=$?
 if [ $RESULT -ne 0 ]; then

--- a/eduplan/CLAUDE.md
+++ b/eduplan/CLAUDE.md
@@ -69,7 +69,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ## Project Overview
 
-**EduPlan** is a student dropout risk detection and intervention tool for Dutch MBO institutions. It uses a **RandomForestRegressor** from [MondriaanBI/Uitnodigingsregel](https://github.com/MondriaanBI/Uitnodigingsregel) to predict dropout risk and generates AI-powered explanations in Dutch via an OpenAI model (the `MODEL` constant in `backend/main.py`).
+**EduPlan** is a student dropout risk detection and intervention tool for Dutch MBO institutions. It uses a **RandomForestRegressor** from [MondriaanBI/Uitnodigingsregel](https://github.com/MondriaanBI/Uitnodigingsregel) to predict dropout risk and generates AI-powered explanations in Dutch via an Anthropic model (the `ANTHROPIC_MODEL` constant in `backend/main.py`, currently `claude-sonnet-4-6`).
 
 ## Running the Application
 
@@ -110,9 +110,9 @@ uv run pytest tests/
 uv run pytest tests/test_backend.py::test_factor_label_binary_value_1
 ```
 
-The test suite uses `fastapi.testclient.TestClient` (no running server needed) and `monkeypatch` to mock the OpenAI client. Tests must be run from inside `eduplan/` so relative paths to `shared/data.csv` and `backend/model.joblib` resolve correctly. Shared fixtures (client, demo_student, mock_openai) live in `tests/conftest.py`. `test_trainer.py` uses an `autouse` fixture `mock_student_signal` that mocks `trainer.prepare` and `trainer.train_random_forest` — keeping trainer tests fast and independent of the student-signal library.
+The test suite uses `fastapi.testclient.TestClient` (no running server needed) and `monkeypatch` to mock the Anthropic client. Tests must be run from inside `eduplan/` so relative paths to `shared/data.csv` and `backend/model.joblib` resolve correctly. Shared fixtures (client, demo_student, mock_anthropic) live in `tests/conftest.py`. `test_trainer.py` uses an `autouse` fixture `mock_student_signal` that mocks `trainer.prepare` and `trainer.train_random_forest` — keeping trainer tests fast and independent of the student-signal library.
 
-There is also a project-root `eduplan/conftest.py` that patches `openai.OpenAI` *before* `backend.main` is imported. This is required because `ALL_PROXY` in the dev environment sets a SOCKS proxy that httpx cannot use without the optional `socksio` package — without this patch, OpenAI client construction at import time would fail. Don't remove it.
+There is also a project-root `eduplan/conftest.py` that patches `anthropic.Anthropic` *before* `backend.main` is imported. This is required because `ALL_PROXY` in the dev environment sets a SOCKS proxy that httpx cannot use without the optional `socksio` package — without this patch, Anthropic client construction at import time would fail. Don't remove it.
 
 **Run the standalone Claude agent CLI:**
 ```bash
@@ -121,8 +121,7 @@ python main.py  # requires ANTHROPIC_API_KEY
 
 ## Required Environment Variables
 
-- `OPENAI_API_KEY` — used by the backend for LLM explanations (model set via the `MODEL` constant in `backend/main.py`)
-- `ANTHROPIC_API_KEY` — used only by `main.py` (the standalone agent CLI)
+- `ANTHROPIC_API_KEY` — used by the backend for LLM explanations (model set via the `ANTHROPIC_MODEL` constant in `backend/main.py`); also used by the standalone Claude agent CLI in `main.py`.
 
 ## Architecture
 
@@ -133,7 +132,7 @@ Streamlit frontend (frontend/app.py)
     → FastAPI backend (backend/main.py)
         → RandomForestRegressor (backend/model.joblib)
         → SHAP TreeExplainer
-        → OpenAI Responses API
+        → Anthropic Messages API
 ```
 
 ### Backend (`backend/main.py`) — 9 endpoints
@@ -143,8 +142,8 @@ Streamlit frontend (frontend/app.py)
 | `POST /rank_students` | `students` (list of dicts) + `use_default_model` | Bulk-ranking: scoort alle studenten in één call, gesorteerd hoog→laag; vervangt N losse `/predict_dropout` calls |
 | `POST /explain_risk` | Student data + probability + `imputed_columns` + `use_default_model` | EduPlan: sectie 1 deterministisch HTML; secties 2–4 via LLM met alleen SHAP-factoren (geen studentprofiel) |
 | `POST /feature_importance` | Student data + `use_default_model` | SHAP values per feature (TreeExplainer on regressor) — used for the UI bar chart |
-| `POST /summarize` | CSV data string or question | Management summary or Q&A via OpenAI |
-| `POST /map_columns` | Uploaded + required column lists | LLM-based column name mapping for CSV uploads |
+| `POST /summarize` | CSV data string or question | Management summary or Q&A via Anthropic |
+| `POST /map_columns` | Uploaded + required column lists | LLM-based column name mapping for CSV uploads; uses Anthropic assistant-turn prefill (`{"role": "assistant", "content": "{"}`) to force well-formed JSON output |
 | `POST /train_model` | `data` (list of dicts) + `dropout_column` + optional `rf_parameters` | Train a custom RandomForest via student-signal; runs in background thread; saves `model_custom.joblib` + `model_custom_features.json` |
 | `GET /train_status` | — | Returns current training state: `idle \| training \| done \| failed` with message |
 | `DELETE /reset_model` | — | Deletes `model_custom.joblib` + `model_custom_features.json` and resets active model to default |
@@ -231,16 +230,16 @@ Risk levels: **LAAG** (< 35%), **MATIG** (35–65%), **HOOG** (≥ 65%).
 - `_SECTOR_COLS` and `_VOOROPL_MAP` — module-level dicts for decoding one-hot sector/education columns in the deterministic profile.
 - `_markdown_to_html()` — converts LLM markdown output to HTML. Calls `html.escape()` first to prevent XSS via raw HTML in LLM responses, then applies bold/italic/list/heading (`#`–`####` → `<h2>`–`<h4>`) regex substitutions.
 
-## OpenAI Client
+## Anthropic Client
 
-The backend uses the **Responses API** (not Chat Completions):
+The backend uses the **Messages API**:
 
 ```python
-response = client.responses.create(model=MODEL, ...)
-text = response.output_text  # NOT .choices[0].message.content
+response = client.messages.create(model=ANTHROPIC_MODEL, max_tokens=2048, ...)
+text = response.content[0].text  # NOT response.output_text
 ```
 
-The `mock_openai` fixture in `tests/conftest.py` mocks `mock_client.responses.create` and sets `mock_response.output_text`. When writing new tests that touch LLM calls, mock this path — not `chat.completions.create`.
+The `mock_anthropic` fixture in `tests/conftest.py` mocks `mock_client.messages.create` and sets `mock_response.content = [MagicMock(text="...")]`. When writing new tests that touch LLM calls, mock this path.
 
 ## Key Implementation Notes
 

--- a/eduplan/backend/README.md
+++ b/eduplan/backend/README.md
@@ -7,9 +7,9 @@ FastAPI backend voor de EduPlan applicatie.
 | Endpoint | Input | Functie |
 |----------|-------|---------|
 | `POST /predict_dropout` | Studentkenmerken + `use_default_model` | Uitvalkans als continue score (0–1) via RandomForestRegressor |
-| `POST /explain_risk` | Studentdata + uitvalkans + `use_default_model` | Nederlandstalige AI-uitleg via GPT-4.1; berekent SHAP intern en stuurt top-5 risicofactoren mee |
+| `POST /explain_risk` | Studentdata + uitvalkans + `use_default_model` | Nederlandstalige AI-uitleg via Claude Sonnet 4.6; berekent SHAP intern en stuurt top-5 risicofactoren mee |
 | `POST /feature_importance` | Studentdata + `use_default_model` | SHAP-waarden per feature (TreeExplainer) — gebruikt door de UI-staafgrafiek |
-| `POST /summarize` | CSV-string of vrije vraag | Managementsamenvatting of Q&A via GPT-4.1 (OpenAI Responses API met code interpreter) |
+| `POST /summarize` | CSV-string of vrije vraag | Managementsamenvatting of Q&A via Claude Sonnet 4.6 (Anthropic Messages API) |
 | `POST /map_columns` | Geüploade + vereiste kolomnamen | LLM-gebaseerde kolomnaam-mapping bij CSV-uploads met afwijkende headers |
 | `POST /train_model` | Studentdata met `Dropout`-kolom + optioneel `rf_parameters` | Start asynchroon GridSearchCV-training; retourneert direct `{"status": "started"}` |
 | `GET /train_status` | — | Geeft huidige trainingsstatus terug: `idle` / `training` / `done` / `failed` |

--- a/eduplan/backend/__init__.py
+++ b/eduplan/backend/__init__.py
@@ -8,7 +8,6 @@
 #     "scikit-learn",
 #     "fastapi",
 #     "uvicorn",
-#     "openai",
 #     "requests",
 #     "plotly",
 #     "shap"

--- a/eduplan/backend/main.py
+++ b/eduplan/backend/main.py
@@ -581,13 +581,13 @@ Maximaal 5 genummerde actiepunten, gesorteerd op urgentie.
 Maak expliciet onderscheid: déze week vs déze maand.
 """
 
-    response = client.responses.create(
-        model=MODEL,
-        store=False,
+    response = anthropic_client.messages.create(
+        model=ANTHROPIC_MODEL,
+        max_tokens=2048,
         temperature=0.2,
-        input=[{"role": "user", "content": prompt}],
+        messages=[{"role": "user", "content": prompt}],
     )
-    sectie2_4 = response.output_text  # type: ignore
+    sectie2_4 = response.content[0].text
 
     # Converteer markdown naar HTML zodat de frontend het correct kan renderen
     sectie2_4_html = _markdown_to_html(sectie2_4)

--- a/eduplan/backend/main.py
+++ b/eduplan/backend/main.py
@@ -8,7 +8,6 @@
 #     "scikit-learn",
 #     "fastapi",
 #     "uvicorn",
-#     "openai",
 #     "requests",
 #     "plotly",
 #     "shap",
@@ -41,7 +40,6 @@ import pandas as pd
 import shap
 from fastapi import FastAPI
 from anthropic import Anthropic
-from openai import OpenAI
 from pydantic import BaseModel
 from sklearn.ensemble import RandomForestRegressor
 
@@ -49,11 +47,7 @@ import backend.trainer as trainer
 
 app = FastAPI()
 
-client = OpenAI()
-
-MODEL = "gpt-5.4-mini-2026-03-17"
-
-anthropic_client = Anthropic()
+client = Anthropic()
 ANTHROPIC_MODEL = "claude-sonnet-4-6"
 
 # Modelpaden
@@ -436,7 +430,7 @@ def _build_risicoprofiel_html(
 @app.post("/summarize")
 def summarize(request: SummaryRequest):
     prompt = f"Vat deze BI-data samen voor het management (max 5 regels):\n{request.data}\nSamenvatting:"
-    response = anthropic_client.messages.create(
+    response = client.messages.create(
         model=ANTHROPIC_MODEL,
         max_tokens=512,
         messages=[{"role": "user", "content": prompt}],
@@ -512,7 +506,7 @@ def explain_risk(request: ExplainRequest):
         urgentie,
         top_factors,
         imputed_set,
-        MODEL,
+        ANTHROPIC_MODEL,
         data_onvoldoende=data_onvoldoende,
     )
 
@@ -581,7 +575,7 @@ Maximaal 5 genummerde actiepunten, gesorteerd op urgentie.
 Maak expliciet onderscheid: déze week vs déze maand.
 """
 
-    response = anthropic_client.messages.create(
+    response = client.messages.create(
         model=ANTHROPIC_MODEL,
         max_tokens=2048,
         temperature=0.2,
@@ -671,7 +665,7 @@ def map_columns(request: MapColumnsRequest):
         "Geef uitsluitend het JSON-object terug, zonder uitleg of markdown.\n\n"
         'Voorbeeld: {"StudentAge": "leeftijd", "absence_unauthorized": "ongeoorloofd_verzuim"}'
     )
-    response = anthropic_client.messages.create(
+    response = client.messages.create(
         model=ANTHROPIC_MODEL,
         max_tokens=1024,
         messages=[

--- a/eduplan/backend/main.py
+++ b/eduplan/backend/main.py
@@ -671,8 +671,15 @@ def map_columns(request: MapColumnsRequest):
         "Geef uitsluitend het JSON-object terug, zonder uitleg of markdown.\n\n"
         'Voorbeeld: {"StudentAge": "leeftijd", "absence_unauthorized": "ongeoorloofd_verzuim"}'
     )
-    response = client.responses.create(model=MODEL, store=False, input=[{"role": "user", "content": prompt}])
-    raw = response.output_text.strip()
+    response = anthropic_client.messages.create(
+        model=ANTHROPIC_MODEL,
+        max_tokens=1024,
+        messages=[
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": "{"},
+        ],
+    )
+    raw = "{" + response.content[0].text.strip()
     json_match = re.search(r"\{.*\}", raw, re.DOTALL)
     try:
         mapping = json.loads(json_match.group()) if json_match else {}

--- a/eduplan/backend/main.py
+++ b/eduplan/backend/main.py
@@ -436,8 +436,12 @@ def _build_risicoprofiel_html(
 @app.post("/summarize")
 def summarize(request: SummaryRequest):
     prompt = f"Vat deze BI-data samen voor het management (max 5 regels):\n{request.data}\nSamenvatting:"
-    response = client.responses.create(model=MODEL, store=False, input=[{"role": "user", "content": prompt}])
-    summary = response.output_text  # type: ignore
+    response = anthropic_client.messages.create(
+        model=ANTHROPIC_MODEL,
+        max_tokens=512,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    summary = response.content[0].text
     return {"summary": summary}
 
 

--- a/eduplan/backend/main.py
+++ b/eduplan/backend/main.py
@@ -40,6 +40,7 @@ import joblib
 import pandas as pd
 import shap
 from fastapi import FastAPI
+from anthropic import Anthropic
 from openai import OpenAI
 from pydantic import BaseModel
 from sklearn.ensemble import RandomForestRegressor
@@ -51,6 +52,9 @@ app = FastAPI()
 client = OpenAI()
 
 MODEL = "gpt-5.4-mini-2026-03-17"
+
+anthropic_client = Anthropic()
+ANTHROPIC_MODEL = "claude-sonnet-4-6"
 
 # Modelpaden
 MODEL_DEFAULT_PATH = "backend/model.joblib"

--- a/eduplan/conftest.py
+++ b/eduplan/conftest.py
@@ -1,15 +1,11 @@
-"""Root conftest — patcht OpenAI én Anthropic vóór backend.main wordt geïmporteerd.
+"""Root conftest — patcht Anthropic vóór backend.main wordt geïmporteerd.
 
 Nodig omdat ALL_PROXY een SOCKS-proxy instelt die httpx niet aankan
-zonder het optionele 'socksio'-pakket. De mocks voorkomen dat de echte
-clients überhaupt worden aangemaakt tijdens tests.
+zonder het optionele 'socksio'-pakket. De mock voorkomt dat de echte
+Anthropic-client überhaupt wordt aangemaakt tijdens tests.
 """
 
 from unittest.mock import MagicMock, patch
-
-# Patch openai.OpenAI vóór elke import van backend.main
-_openai_patcher = patch("openai.OpenAI", return_value=MagicMock())
-_openai_patcher.start()
 
 # Patch anthropic.Anthropic vóór elke import van backend.main
 _anthropic_patcher = patch("anthropic.Anthropic", return_value=MagicMock())

--- a/eduplan/conftest.py
+++ b/eduplan/conftest.py
@@ -1,8 +1,8 @@
-"""Root conftest — patcht OpenAI vóór backend.main wordt geïmporteerd.
+"""Root conftest — patcht OpenAI én Anthropic vóór backend.main wordt geïmporteerd.
 
 Nodig omdat ALL_PROXY een SOCKS-proxy instelt die httpx niet aankan
-zonder het optionele 'socksio'-pakket. De mock voorkomt dat de echte
-OpenAI-client überhaupt wordt aangemaakt tijdens tests.
+zonder het optionele 'socksio'-pakket. De mocks voorkomen dat de echte
+clients überhaupt worden aangemaakt tijdens tests.
 """
 
 from unittest.mock import MagicMock, patch
@@ -10,3 +10,7 @@ from unittest.mock import MagicMock, patch
 # Patch openai.OpenAI vóór elke import van backend.main
 _openai_patcher = patch("openai.OpenAI", return_value=MagicMock())
 _openai_patcher.start()
+
+# Patch anthropic.Anthropic vóór elke import van backend.main
+_anthropic_patcher = patch("anthropic.Anthropic", return_value=MagicMock())
+_anthropic_patcher.start()

--- a/eduplan/docs/superpowers/plans/2026-05-18-anthropic-llm-migration.md
+++ b/eduplan/docs/superpowers/plans/2026-05-18-anthropic-llm-migration.md
@@ -1,0 +1,650 @@
+# EduPlan: Migrate Backend LLM from OpenAI to Anthropic (Sonnet 4.6) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Also invoke `claude-api` skill when touching SDK call sites — it triggers on `import anthropic` and documents prompt caching + Messages API patterns.
+
+**Goal:** Replace OpenAI Responses API calls in `eduplan/backend/main.py` (3 endpoints) with Anthropic Messages API calls using `claude-sonnet-4-6`, preserving Dutch output quality and all existing test behavior.
+
+**Architecture:** Dual-client during migration. Add an `anthropic_client = Anthropic()` next to the existing `client = OpenAI()`. Migrate one endpoint at a time so the suite stays green at every checkpoint. After all three endpoints are on Anthropic, remove the OpenAI client, the dep, and the legacy mock fixture in a single cleanup task.
+
+**Tech Stack:** Python 3.13, FastAPI, `anthropic` SDK (new dep), pytest with `fastapi.testclient.TestClient`, `monkeypatch` for client swap, UV for env management.
+
+**Constraints from the codebase (verified before writing this plan):**
+- Three call sites in `backend/main.py`: `/summarize` (line ~435), `/explain_risk` (line ~576), `/map_columns` (line ~666). All use `client.responses.create(...)` and read `response.output_text`.
+- Test fixture `mock_openai` in `tests/conftest.py:30-40` patches `client.responses.create.return_value.output_text`. Seven tests in `tests/test_backend.py` use this fixture; two of them assert `mock_openai.responses.create.called`.
+- Root `conftest.py` patches `openai.OpenAI` **before** `backend.main` imports (required because `ALL_PROXY` SOCKS proxy breaks real client construction at import time). Adding `Anthropic()` at module level requires an equivalent root-level patch, otherwise the test suite fails to collect.
+- `pyproject.toml` pins `scikit-learn==1.6.1` exactly (model compatibility). Do not touch this. `openai>=2.26.0` will be removed in the final cleanup task.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `eduplan/pyproject.toml` | modify | Add `anthropic` dep (Task 1); remove `openai` dep (Task 5). |
+| `eduplan/conftest.py` | modify | Add `patch("anthropic.Anthropic", ...)` next to existing OpenAI patch (Task 1); remove OpenAI patch (Task 5). |
+| `eduplan/tests/conftest.py` | modify | Add `mock_anthropic` fixture (Task 1); remove `mock_openai` fixture (Task 5). |
+| `eduplan/backend/main.py` | modify | Add `anthropic_client = Anthropic()` and `ANTHROPIC_MODEL` constant (Task 1); migrate `/summarize` (Task 2), `/map_columns` (Task 3), `/explain_risk` (Task 4); remove OpenAI client + `MODEL` (Task 5). |
+| `eduplan/tests/test_backend.py` | modify | Per-endpoint, swap `mock_openai` → `mock_anthropic` in the migrated endpoint's tests (Tasks 2–4); remove residual `mock_openai` references (Task 5). |
+| `eduplan/CLAUDE.md` | modify | Update LLM provider notes + env var requirement (Task 6). |
+| `CLAUDE.md` (repo root) | modify | Update sub-project description re: provider (Task 6). |
+
+---
+
+## Task 1: Add Anthropic side-by-side (deps + conftest patches + mock fixture + client init)
+
+**Files:**
+- Modify: `eduplan/pyproject.toml` (add anthropic to dependencies)
+- Modify: `eduplan/conftest.py` (add Anthropic patch before backend.main import)
+- Modify: `eduplan/tests/conftest.py` (add mock_anthropic fixture)
+- Modify: `eduplan/backend/main.py` (import + client construction; do NOT touch endpoints yet)
+
+- [ ] **Step 1.1: Add anthropic dependency**
+
+Edit `eduplan/pyproject.toml`, add `"anthropic>=0.43.0",` to the `dependencies` list (alphabetically, after `"openai>=2.26.0",`). The full list of dependencies should now include both providers — OpenAI stays during the migration.
+
+- [ ] **Step 1.2: Run uv sync to install**
+
+```bash
+cd eduplan && uv sync --extra dev
+```
+
+Expected: completes without error; lockfile updates to include `anthropic` and its transitive deps (`httpx`, `pydantic`, etc. — already pinned).
+
+- [ ] **Step 1.3: Patch Anthropic in root conftest BEFORE backend.main import**
+
+Edit `eduplan/conftest.py` to look exactly like this:
+
+```python
+"""Root conftest — patcht OpenAI én Anthropic vóór backend.main wordt geïmporteerd.
+
+Nodig omdat ALL_PROXY een SOCKS-proxy instelt die httpx niet aankan
+zonder het optionele 'socksio'-pakket. De mocks voorkomen dat de echte
+clients überhaupt worden aangemaakt tijdens tests.
+"""
+
+from unittest.mock import MagicMock, patch
+
+# Patch openai.OpenAI vóór elke import van backend.main
+_openai_patcher = patch("openai.OpenAI", return_value=MagicMock())
+_openai_patcher.start()
+
+# Patch anthropic.Anthropic vóór elke import van backend.main
+_anthropic_patcher = patch("anthropic.Anthropic", return_value=MagicMock())
+_anthropic_patcher.start()
+```
+
+- [ ] **Step 1.4: Add the Anthropic client + model constant to backend/main.py**
+
+In `eduplan/backend/main.py`, find the line `from openai import OpenAI` (around line 43) and add directly below it:
+
+```python
+from anthropic import Anthropic
+```
+
+Find the lines `client = OpenAI()` and `MODEL = "gpt-5.4-mini-2026-03-17"` (around lines 51–53) and add directly below them:
+
+```python
+anthropic_client = Anthropic()
+ANTHROPIC_MODEL = "claude-sonnet-4-6"
+```
+
+Do NOT modify any endpoint code in this task. Both clients now co-exist.
+
+- [ ] **Step 1.5: Add mock_anthropic fixture in tests/conftest.py**
+
+Edit `eduplan/tests/conftest.py` to add this fixture **below** the existing `mock_openai` fixture (do not remove `mock_openai` yet):
+
+```python
+@pytest.fixture
+def mock_anthropic(monkeypatch) -> MagicMock:
+    """Vervangt de Anthropic-client in backend.main door een mock."""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Gemockte LLM-uitvoer")]
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+    import backend.main as main_mod
+
+    monkeypatch.setattr(main_mod, "anthropic_client", mock_client)
+    return mock_client
+```
+
+- [ ] **Step 1.6: Run full test suite to confirm nothing broke**
+
+```bash
+cd eduplan && uv run pytest tests/ -v
+```
+
+Expected: all existing tests pass (still using `mock_openai`, since no endpoint code changed). If any test fails at collection time with `anthropic.Anthropic` errors, Step 1.3 was not applied correctly.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+cd eduplan && git add pyproject.toml uv.lock conftest.py tests/conftest.py backend/main.py
+git commit -m "$(cat <<'EOF'
+eduplan: add Anthropic client alongside OpenAI for migration
+
+Introduce anthropic dep, dual-patch in root conftest, and a parallel mock_anthropic fixture. No endpoint behavior changes yet.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Migrate `/summarize` endpoint (smallest, no JSON parsing)
+
+**Files:**
+- Modify: `eduplan/backend/main.py` (the `summarize` function, around lines 432–437)
+- Modify: `eduplan/tests/test_backend.py` (`test_summarize_returns_summary`, line ~236)
+
+- [ ] **Step 2.1: Swap test fixture from mock_openai to mock_anthropic**
+
+In `eduplan/tests/test_backend.py`, change the test signature from:
+
+```python
+def test_summarize_returns_summary(client, mock_openai):
+    resp = client.post("/summarize", json={"data": "student1,student2"})
+    assert resp.status_code == 200
+    assert "summary" in resp.json()
+    assert resp.json()["summary"] == "Gemockte LLM-uitvoer"
+```
+
+to:
+
+```python
+def test_summarize_returns_summary(client, mock_anthropic):
+    resp = client.post("/summarize", json={"data": "student1,student2"})
+    assert resp.status_code == 200
+    assert "summary" in resp.json()
+    assert resp.json()["summary"] == "Gemockte LLM-uitvoer"
+```
+
+- [ ] **Step 2.2: Run the test to confirm it FAILS (endpoint still uses OpenAI)**
+
+```bash
+cd eduplan && uv run pytest tests/test_backend.py::test_summarize_returns_summary -v
+```
+
+Expected: FAIL (the endpoint still calls `client.responses.create`, and the mock_anthropic fixture didn't intercept it, so the real OpenAI mock returns a MagicMock object whose `.output_text` is a MagicMock, not the string `"Gemockte LLM-uitvoer"`).
+
+- [ ] **Step 2.3: Migrate the endpoint code**
+
+In `eduplan/backend/main.py`, find the `summarize` function and replace it with:
+
+```python
+@app.post("/summarize")
+def summarize(request: SummaryRequest):
+    prompt = f"Vat deze BI-data samen voor het management (max 5 regels):\n{request.data}\nSamenvatting:"
+    response = anthropic_client.messages.create(
+        model=ANTHROPIC_MODEL,
+        max_tokens=512,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    summary = response.content[0].text
+    return {"summary": summary}
+```
+
+- [ ] **Step 2.4: Run the test — expect PASS**
+
+```bash
+cd eduplan && uv run pytest tests/test_backend.py::test_summarize_returns_summary -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.5: Run full suite to confirm no regression**
+
+```bash
+cd eduplan && uv run pytest tests/ -v
+```
+
+Expected: all tests still green.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+cd eduplan && git add backend/main.py tests/test_backend.py
+git commit -m "$(cat <<'EOF'
+eduplan: migrate /summarize to Anthropic Sonnet 4.6
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Migrate `/map_columns` endpoint (JSON output — use assistant prefill)
+
+**Files:**
+- Modify: `eduplan/backend/main.py` (the `map_columns` function, around lines 652–673)
+- Modify: `eduplan/tests/test_backend.py` (`test_map_columns_returns_mapping` line ~243 and `test_map_columns_invalid_json_returns_empty` line ~259)
+
+- [ ] **Step 3.1: Swap fixtures and update mock attribute paths in both tests**
+
+In `eduplan/tests/test_backend.py`, replace `test_map_columns_returns_mapping` with:
+
+```python
+def test_map_columns_returns_mapping(client, mock_anthropic):
+    mock_anthropic.messages.create.return_value.content = [
+        MagicMock(text='"StudentAge": "leeftijd", "absence_unauthorized": "verzuim"}')
+    ]
+    resp = client.post(
+        "/map_columns",
+        json={
+            "uploaded_columns": ["leeftijd", "verzuim"],
+            "required_columns": ["StudentAge", "absence_unauthorized"],
+        },
+    )
+    assert resp.status_code == 200
+    mapping = resp.json()["mapping"]
+    assert mapping.get("StudentAge") == "leeftijd"
+```
+
+Note: the mocked text starts with `"StudentAge"...` (no leading `{`) because the endpoint will use assistant prefill — see Step 3.2. The endpoint prepends `{` before parsing.
+
+Replace `test_map_columns_invalid_json_returns_empty` with:
+
+```python
+def test_map_columns_invalid_json_returns_empty(client, mock_anthropic):
+    """Ongeldige LLM-output levert een leeg mapping-object op (geen crash)."""
+    mock_anthropic.messages.create.return_value.content = [MagicMock(text="geen json hier")]
+    resp = client.post(
+        "/map_columns",
+        json={"uploaded_columns": ["x"], "required_columns": ["StudentAge"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["mapping"] == {}
+```
+
+- [ ] **Step 3.2: Migrate the endpoint code with assistant-prefill JSON pattern**
+
+In `eduplan/backend/main.py`, replace the `map_columns` function with:
+
+```python
+@app.post("/map_columns")
+def map_columns(request: MapColumnsRequest):
+    """Gebruik LLM om geüploade kolomnamen te koppelen aan vereiste kolomnamen."""
+    prompt = (
+        "Je krijgt twee lijsten met kolomnamen van datasets.\n\n"
+        f"Geüploade kolommen: {request.uploaded_columns}\n"
+        f"Vereiste kolommen: {request.required_columns}\n\n"
+        "Geef een JSON-object terug waarbij de sleutels de VEREISTE kolomnamen zijn "
+        "en de waarden de overeenkomende GEÜPLOADE kolomnamen. "
+        "Neem alleen kolommen op waarbij je zeker bent van de overeenkomst op basis van "
+        "betekenis of naamgelijkenis (bijv. 'leeftijd' → 'StudentAge', 'verzuim' → 'absence_unauthorized'). "
+        "Geef uitsluitend het JSON-object terug, zonder uitleg of markdown.\n\n"
+        'Voorbeeld: {"StudentAge": "leeftijd", "absence_unauthorized": "ongeoorloofd_verzuim"}'
+    )
+    response = anthropic_client.messages.create(
+        model=ANTHROPIC_MODEL,
+        max_tokens=1024,
+        messages=[
+            {"role": "user", "content": prompt},
+            {"role": "assistant", "content": "{"},
+        ],
+    )
+    raw = "{" + response.content[0].text.strip()
+    json_match = re.search(r"\{.*\}", raw, re.DOTALL)
+    try:
+        mapping = json.loads(json_match.group()) if json_match else {}
+    except Exception:
+        mapping = {}
+    return {"mapping": mapping}
+```
+
+The `{"role": "assistant", "content": "{"}` prefill forces the model to continue with valid JSON; we prepend the `{` ourselves when parsing.
+
+- [ ] **Step 3.3: Run both map_columns tests — expect PASS**
+
+```bash
+cd eduplan && uv run pytest tests/test_backend.py::test_map_columns_returns_mapping tests/test_backend.py::test_map_columns_invalid_json_returns_empty -v
+```
+
+Expected: both PASS.
+
+- [ ] **Step 3.4: Run full suite to confirm no regression**
+
+```bash
+cd eduplan && uv run pytest tests/ -v
+```
+
+Expected: all green.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+cd eduplan && git add backend/main.py tests/test_backend.py
+git commit -m "$(cat <<'EOF'
+eduplan: migrate /map_columns to Anthropic with assistant-prefill JSON
+
+Uses assistant-turn prefill ("{") to force well-formed JSON output from Sonnet 4.6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Migrate `/explain_risk` endpoint (largest, 4 tests touch it)
+
+**Files:**
+- Modify: `eduplan/backend/main.py` (the LLM call inside `explain_risk`, around lines 573–582)
+- Modify: `eduplan/tests/test_backend.py` (4 tests: `test_explain_risk_returns_sectie1_html`, `test_explain_risk_llm_called_when_shap_sufficient`, `test_explain_risk_data_onvoldoende_skips_llm`, `test_explain_risk_laag_risico`)
+
+- [ ] **Step 4.1: Swap fixtures + the .called assertion in all 4 explain_risk tests**
+
+In `eduplan/tests/test_backend.py`, find every `mock_openai` parameter in the four `test_explain_risk_*` functions and rename to `mock_anthropic`. Also update the two assertions that check `.responses.create.called`:
+
+- Line ~202: `assert mock_openai.responses.create.called` → `assert mock_anthropic.messages.create.called`
+- Line ~215: `assert not mock_openai.responses.create.called` → `assert not mock_anthropic.messages.create.called`
+
+- [ ] **Step 4.2: Run the 4 explain_risk tests — expect FAIL on the LLM-called assertions**
+
+```bash
+cd eduplan && uv run pytest tests/test_backend.py -k explain_risk -v
+```
+
+Expected: at least `test_explain_risk_llm_called_when_shap_sufficient` FAILS because the endpoint still uses `client.responses.create`, not `anthropic_client.messages.create`.
+
+- [ ] **Step 4.3: Migrate the LLM call in explain_risk**
+
+In `eduplan/backend/main.py`, find the block (currently around lines 573–582):
+
+```python
+    response = client.responses.create(
+        model=MODEL,
+        store=False,
+        temperature=0.2,
+        input=[{"role": "user", "content": prompt}],
+    )
+    sectie2_4 = response.output_text  # type: ignore
+
+    # Converteer markdown naar HTML zodat de frontend het correct kan renderen
+    sectie2_4_html = _markdown_to_html(sectie2_4)
+```
+
+Replace with:
+
+```python
+    response = anthropic_client.messages.create(
+        model=ANTHROPIC_MODEL,
+        max_tokens=2048,
+        temperature=0.2,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    sectie2_4 = response.content[0].text
+
+    # Converteer markdown naar HTML zodat de frontend het correct kan renderen
+    sectie2_4_html = _markdown_to_html(sectie2_4)
+```
+
+- [ ] **Step 4.4: Run the 4 explain_risk tests — expect PASS**
+
+```bash
+cd eduplan && uv run pytest tests/test_backend.py -k explain_risk -v
+```
+
+Expected: all 4 PASS.
+
+- [ ] **Step 4.5: Run full suite to confirm no regression**
+
+```bash
+cd eduplan && uv run pytest tests/ -v
+```
+
+Expected: all tests green. `mock_openai` fixture should now be unused by any test, but is still defined; that's fine — Task 5 removes it.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+cd eduplan && git add backend/main.py tests/test_backend.py
+git commit -m "$(cat <<'EOF'
+eduplan: migrate /explain_risk to Anthropic Sonnet 4.6
+
+Last of three LLM endpoints migrated. mock_openai fixture is now unused and will be removed in cleanup.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Cleanup — remove OpenAI client, dep, mock fixture, and root patch
+
+**Files:**
+- Modify: `eduplan/backend/main.py` (drop OpenAI import + client + MODEL constant)
+- Modify: `eduplan/conftest.py` (drop OpenAI patch)
+- Modify: `eduplan/tests/conftest.py` (drop mock_openai fixture)
+- Modify: `eduplan/pyproject.toml` (drop openai dep)
+
+- [ ] **Step 5.1: Verify no remaining references to OpenAI in code**
+
+```bash
+cd eduplan && grep -rn "openai\|OpenAI\|client\.responses\|output_text\|mock_openai" backend/ tests/ conftest.py
+```
+
+Expected: matches only in `conftest.py`, `tests/conftest.py` (the fixture and root patch) and `backend/main.py` (`from openai import OpenAI` + `client = OpenAI()` + `MODEL = ...`). If anything else shows up, fix it before continuing.
+
+- [ ] **Step 5.2: Remove OpenAI import + client + MODEL from backend/main.py**
+
+In `eduplan/backend/main.py`, delete the line `from openai import OpenAI`. Delete the lines `client = OpenAI()` and `MODEL = "gpt-5.4-mini-2026-03-17"`. Optionally rename `anthropic_client` → `client` for brevity (recommended — fewer renames are clearer). If renaming:
+- Find all `anthropic_client.messages.create` (3 sites) and replace with `client.messages.create`.
+- In `eduplan/tests/conftest.py`, change the `monkeypatch.setattr(main_mod, "anthropic_client", mock_client)` line in the `mock_anthropic` fixture to `monkeypatch.setattr(main_mod, "client", mock_client)`.
+
+- [ ] **Step 5.3: Remove the OpenAI patch from root conftest.py**
+
+Edit `eduplan/conftest.py` to:
+
+```python
+"""Root conftest — patcht Anthropic vóór backend.main wordt geïmporteerd.
+
+Nodig omdat ALL_PROXY een SOCKS-proxy instelt die httpx niet aankan
+zonder het optionele 'socksio'-pakket. De mock voorkomt dat de echte
+Anthropic-client überhaupt wordt aangemaakt tijdens tests.
+"""
+
+from unittest.mock import MagicMock, patch
+
+# Patch anthropic.Anthropic vóór elke import van backend.main
+_anthropic_patcher = patch("anthropic.Anthropic", return_value=MagicMock())
+_anthropic_patcher.start()
+```
+
+- [ ] **Step 5.4: Remove the mock_openai fixture from tests/conftest.py**
+
+In `eduplan/tests/conftest.py`, delete the entire `mock_openai` fixture (the `@pytest.fixture\ndef mock_openai(monkeypatch) -> MagicMock:` block and its body).
+
+- [ ] **Step 5.5: Remove openai dep from pyproject.toml**
+
+In `eduplan/pyproject.toml`, remove the line `"openai>=2.26.0",` from `[project].dependencies`.
+
+- [ ] **Step 5.6: Re-sync to drop openai from the lockfile**
+
+```bash
+cd eduplan && uv sync --extra dev
+```
+
+Expected: `openai` and its transitive deps are uninstalled; lockfile updates.
+
+- [ ] **Step 5.7: Run full suite to confirm nothing regressed**
+
+```bash
+cd eduplan && uv run pytest tests/ -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.8: Confirm import surface is clean**
+
+```bash
+cd eduplan && uv run python -c "import backend.main; print('OK')"
+```
+
+Expected: prints `OK`. No `ImportError` for `openai`.
+
+- [ ] **Step 5.9: Commit**
+
+```bash
+cd eduplan && git add backend/main.py conftest.py tests/conftest.py pyproject.toml uv.lock
+git commit -m "$(cat <<'EOF'
+eduplan: drop OpenAI dep — fully migrated to Anthropic Sonnet 4.6
+
+Removes openai import, client init, MODEL constant, mock_openai fixture, root OpenAI patch, and the dep itself.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Update documentation
+
+**Files:**
+- Modify: `eduplan/CLAUDE.md`
+- Modify: `CLAUDE.md` (repo root)
+
+- [ ] **Step 6.1: Update eduplan/CLAUDE.md provider references**
+
+In `eduplan/CLAUDE.md`, find every reference to OpenAI / gpt-5.4-mini and adjust:
+
+- Project Overview line "It uses a **RandomForestRegressor** … via an OpenAI model (the `MODEL` constant in `backend/main.py`)" → replace `OpenAI model (the `MODEL` constant ...)` with `Anthropic model (`claude-sonnet-4-6`, set via `ANTHROPIC_MODEL` in `backend/main.py`)`.
+- Required Environment Variables section: change `OPENAI_API_KEY` line to `ANTHROPIC_API_KEY — used by the backend for LLM explanations (model set via the `ANTHROPIC_MODEL` constant in `backend/main.py`)`. Remove the separate `ANTHROPIC_API_KEY` line about `main.py` only — that one is now redundant because the same key powers both.
+- "OpenAI Client" section heading and the code example: rename to "Anthropic Client" and update the example to:
+
+  ```python
+  response = client.messages.create(model=ANTHROPIC_MODEL, max_tokens=2048, ...)
+  text = response.content[0].text  # NOT .output_text
+  ```
+
+  Update the trailing paragraph about the `mock_openai` fixture: replace with a description of `mock_anthropic` that mocks `mock_client.messages.create` and sets `mock_response.content = [MagicMock(text=...)]`.
+
+- The bullet about `eduplan/conftest.py` patching `openai.OpenAI` → update to `anthropic.Anthropic`.
+
+- [ ] **Step 6.2: Update root CLAUDE.md sub-project description**
+
+In `CLAUDE.md` (repo root), find the EduPlan Sub-Project section. Change "Env vars: `OPENAI_API_KEY` (backend GPT-4.1 via Responses API), `ANTHROPIC_API_KEY` (standalone agent CLI only)" to: "Env vars: `ANTHROPIC_API_KEY` (backend Sonnet 4.6 via Messages API; also used by the standalone agent CLI)".
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+cd eduplan && git add CLAUDE.md ../CLAUDE.md
+git commit -m "$(cat <<'EOF'
+docs: update CLAUDE.md after Anthropic migration
+
+Update provider references, env-var requirements, and client examples to reflect Sonnet 4.6 via Messages API.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Manual quality verification against real Anthropic API
+
+This is the only task that actually validates the user's "met behoud van kwaliteit" requirement. The mock-based tests pass regardless of provider.
+
+**Setup:**
+- Confirm `ANTHROPIC_API_KEY` is set in the shell.
+- Confirm backend default model file (`backend/model.joblib`) is present.
+
+- [ ] **Step 7.1: Capture an "old" sample before merging (optional but recommended)**
+
+If you can still run the OpenAI version (e.g., from `main` before merge):
+
+```bash
+git stash  # if uncommitted; or check out the pre-migration commit in a worktree
+cd eduplan && ./1_start_fastapi.sh &
+./2_start_streamlit.sh &
+```
+
+Pick 3 demo students from `shared/data.csv` at LAAG (<35%), MATIG (35–65%), and HOOG (≥65%) risk. Generate the EduPlan for each via the UI (UITNODIGINGSREGEL → select student → EDUPLAN → TOON EDUPLAN). Save the rendered explanation HTML to `/tmp/eduplan_openai_<risico>.html`.
+
+Stop both processes; restore the branch.
+
+- [ ] **Step 7.2: Start backend + frontend on the migrated branch**
+
+```bash
+cd eduplan && ./1_start_fastapi.sh
+# In separate terminal:
+cd eduplan && ./2_start_streamlit.sh
+```
+
+Backend: `http://localhost:8000` (docs at `/docs`). Frontend: `http://localhost:8502`.
+
+- [ ] **Step 7.3: Smoke-test each endpoint via the Streamlit UI using chrome-devtools-mcp**
+
+Per the user's standing preference (see memory `feedback_ui_smoke_test_after_migration.md`), pytest green ≠ feature working after provider swaps. Use chrome-devtools-mcp:
+
+1. `mcp__plugin_chrome-devtools-mcp_chrome-devtools__new_page` → `http://localhost:8502`
+2. Select an opleiding from the start screen.
+3. UITNODIGINGSREGEL tab: confirm the ranking bar chart renders (this exercises `/rank_students` — no LLM, but verifies the app still works end-to-end).
+4. EDUPLAN tab: pick the HOOG-risk student → click TOON EDUPLAN → wait for response (`/explain_risk` real API call). Confirm:
+   - Section 1 (deterministic) renders correctly.
+   - Sections 2–4 render with **rendered** headings (`<h2>`/`<h3>`), bold, lists — not raw markdown. (This was the previous regression — verify the heading fix from commit `8cd5cf1` still works.)
+   - Dutch is natural, professional, and references only the listed factors (no hallucinated age/gender/verzuim numbers).
+5. Repeat for MATIG and LAAG students.
+6. Upload a CSV (use `shared/data.csv`) to trigger `/map_columns`. Confirm the column mapping JSON is parsed correctly.
+7. Trigger `/summarize` if a UI path exists for it.
+
+- [ ] **Step 7.4: Side-by-side quality eyeball (if Step 7.1 was done)**
+
+Open `/tmp/eduplan_openai_<risico>.html` next to the new Anthropic output. Compare on:
+- **Factor-grounding:** Does the new output stick to the listed SHAP factors, or hallucinate?
+- **Dutch fluency:** Idiomatic? Professional MBO register?
+- **Concreteness:** Are gespreksstarters and interventions specific, or vague?
+- **Length:** Roughly equivalent? (max_tokens=2048 should be enough; if outputs are truncated, raise to 3072 in `explain_risk`.)
+
+Record findings in a brief note. If quality is materially worse, this task does NOT pass — iterate on `max_tokens`, prompt phrasing, or fall back. If quality is on-par or better, proceed.
+
+- [ ] **Step 7.5: Final commit (if any prompt/max_tokens adjustments were needed)**
+
+```bash
+cd eduplan && git add backend/main.py
+git commit -m "$(cat <<'EOF'
+eduplan: tune Sonnet 4.6 max_tokens / prompt after quality check
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 7.6: Push the full migration**
+
+```bash
+cd eduplan && git push
+```
+
+---
+
+## Self-Review (against the spec)
+
+**Spec coverage:**
+- "Omzetten naar Anthropic Sonnet 4.6" → Tasks 1–5 (every callsite migrated, OpenAI dep removed). ✓
+- "Met behoud van kwaliteit" → Task 7 (real-API quality check, side-by-side eyeball). ✓
+- "Niet triviaal — drie callsites + tests + conftest patches" → addressed in Tasks 2–4 (one endpoint each) and Task 1 (dual conftest patch). ✓
+- JSON-output endpoint (`/map_columns`) reliability with Anthropic → Task 3 uses assistant-prefill pattern. ✓
+- Test suite must stay green at every checkpoint → each task ends with a full-suite run before commit. ✓
+
+**Placeholders:** None. Every step has exact paths, exact code, and exact commands.
+
+**Type consistency:** `ANTHROPIC_MODEL` (constant name) and `anthropic_client` (variable) — used consistently across Tasks 1–4. Task 5 optionally renames `anthropic_client` → `client`; that rename is explicit (3 callsites + 1 fixture line).
+
+**Risk:** the optional rename in Step 5.2 could be skipped to reduce diff size. If it is skipped, Step 5.4 must NOT remove the `monkeypatch.setattr(main_mod, "anthropic_client", mock_client)` line — only `mock_openai` is removed.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `eduplan/docs/superpowers/plans/2026-05-18-anthropic-llm-migration.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, fast iteration. Each task is small enough (~5–15 min) to dispatch independently.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, with checkpoints between Tasks 1, 4, 5, and 7 for review.
+
+Which approach?

--- a/eduplan/pyproject.toml
+++ b/eduplan/pyproject.toml
@@ -11,6 +11,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "anthropic>=0.43.0",
     "fastapi>=0.135.1",
     "openai>=2.26.0",
     "pandas>=2.3.3",

--- a/eduplan/pyproject.toml
+++ b/eduplan/pyproject.toml
@@ -13,7 +13,6 @@ requires-python = ">=3.13"
 dependencies = [
     "anthropic>=0.43.0",
     "fastapi>=0.135.1",
-    "openai>=2.26.0",
     "pandas>=2.3.3",
     "pillow>=12.1.1",
     "plotly>=6.6.0",

--- a/eduplan/requirements.txt
+++ b/eduplan/requirements.txt
@@ -4,7 +4,7 @@ pandas
 scikit-learn 
 fastapi 
 uvicorn 
-openai 
+anthropic
 requests 
 plotly 
 shap

--- a/eduplan/tests/conftest.py
+++ b/eduplan/tests/conftest.py
@@ -38,3 +38,16 @@ def mock_openai(monkeypatch) -> MagicMock:
 
     monkeypatch.setattr(main_mod, "client", mock_client)
     return mock_client
+
+
+@pytest.fixture
+def mock_anthropic(monkeypatch) -> MagicMock:
+    """Vervangt de Anthropic-client in backend.main door een mock."""
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="Gemockte LLM-uitvoer")]
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+    import backend.main as main_mod
+
+    monkeypatch.setattr(main_mod, "anthropic_client", mock_client)
+    return mock_client

--- a/eduplan/tests/conftest.py
+++ b/eduplan/tests/conftest.py
@@ -28,19 +28,6 @@ def demo_student() -> dict:
 
 
 @pytest.fixture
-def mock_openai(monkeypatch) -> MagicMock:
-    """Vervangt de OpenAI-client in backend.main door een mock."""
-    mock_response = MagicMock()
-    mock_response.output_text = "Gemockte LLM-uitvoer"
-    mock_client = MagicMock()
-    mock_client.responses.create.return_value = mock_response
-    import backend.main as main_mod
-
-    monkeypatch.setattr(main_mod, "client", mock_client)
-    return mock_client
-
-
-@pytest.fixture
 def mock_anthropic(monkeypatch) -> MagicMock:
     """Vervangt de Anthropic-client in backend.main door een mock."""
     mock_response = MagicMock()
@@ -49,5 +36,5 @@ def mock_anthropic(monkeypatch) -> MagicMock:
     mock_client.messages.create.return_value = mock_response
     import backend.main as main_mod
 
-    monkeypatch.setattr(main_mod, "anthropic_client", mock_client)
+    monkeypatch.setattr(main_mod, "client", mock_client)
     return mock_client

--- a/eduplan/tests/test_backend.py
+++ b/eduplan/tests/test_backend.py
@@ -233,7 +233,7 @@ def test_explain_risk_laag_risico(client, demo_student, mock_openai):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def test_summarize_returns_summary(client, mock_openai):
+def test_summarize_returns_summary(client, mock_anthropic):
     resp = client.post("/summarize", json={"data": "student1,student2"})
     assert resp.status_code == 200
     assert "summary" in resp.json()

--- a/eduplan/tests/test_backend.py
+++ b/eduplan/tests/test_backend.py
@@ -240,10 +240,10 @@ def test_summarize_returns_summary(client, mock_anthropic):
     assert resp.json()["summary"] == "Gemockte LLM-uitvoer"
 
 
-def test_map_columns_returns_mapping(client, mock_openai):
-    mock_openai.responses.create.return_value.output_text = (
-        '{"StudentAge": "leeftijd", "absence_unauthorized": "verzuim"}'
-    )
+def test_map_columns_returns_mapping(client, mock_anthropic):
+    mock_anthropic.messages.create.return_value.content = [
+        MagicMock(text='"StudentAge": "leeftijd", "absence_unauthorized": "verzuim"}')
+    ]
     resp = client.post(
         "/map_columns",
         json={
@@ -256,9 +256,9 @@ def test_map_columns_returns_mapping(client, mock_openai):
     assert mapping.get("StudentAge") == "leeftijd"
 
 
-def test_map_columns_invalid_json_returns_empty(client, mock_openai):
+def test_map_columns_invalid_json_returns_empty(client, mock_anthropic):
     """Ongeldige LLM-output levert een leeg mapping-object op (geen crash)."""
-    mock_openai.responses.create.return_value.output_text = "geen json hier"
+    mock_anthropic.messages.create.return_value.content = [MagicMock(text="geen json hier")]
     resp = client.post(
         "/map_columns",
         json={"uploaded_columns": ["x"], "required_columns": ["StudentAge"]},

--- a/eduplan/tests/test_backend.py
+++ b/eduplan/tests/test_backend.py
@@ -56,7 +56,7 @@ def test_build_risicoprofiel_hoog_bevat_risiconiveau():
         urgentie="directe actie vereist (deze week)",
         top_factors=[("absence_unauthorized", 0.12)],
         imputed_set=set(),
-        model_name="gpt-4.1",
+        model_name="claude-sonnet-4-6",
     )
     assert "HOOG" in html
     assert "75%" in html
@@ -70,7 +70,7 @@ def test_build_risicoprofiel_matig():
         urgentie="actie aanbevolen binnen twee weken",
         top_factors=[],
         imputed_set=set(),
-        model_name="gpt-4.1",
+        model_name="claude-sonnet-4-6",
     )
     assert "MATIG" in html
 
@@ -83,7 +83,7 @@ def test_build_risicoprofiel_imputed_field_toont_niet_beschikbaar():
         urgentie="actie aanbevolen binnen twee weken",
         top_factors=[],
         imputed_set={"StudentAge", "absence_unauthorized"},
-        model_name="gpt-4.1",
+        model_name="claude-sonnet-4-6",
     )
     assert "niet beschikbaar" in html
 
@@ -96,7 +96,7 @@ def test_build_risicoprofiel_data_onvoldoende_toont_waarschuwing():
         urgentie="reguliere monitoring volstaat",
         top_factors=[("StudentAge", 0.001)],
         imputed_set={"StudentAge"},
-        model_name="gpt-4.1",
+        model_name="claude-sonnet-4-6",
         data_onvoldoende=True,
     )
     assert "Datakwaliteit" in html or "onvoldoende" in html.lower()

--- a/eduplan/tests/test_backend.py
+++ b/eduplan/tests/test_backend.py
@@ -163,7 +163,7 @@ def test_feature_importance_values_are_floats(client, demo_student):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def test_explain_risk_returns_sectie1_html(client, demo_student, mock_openai):
+def test_explain_risk_returns_sectie1_html(client, demo_student, mock_anthropic):
     payload = {
         "student": demo_student,
         "prediction": 1,
@@ -177,7 +177,7 @@ def test_explain_risk_returns_sectie1_html(client, demo_student, mock_openai):
     assert "HOOG" in explanation
 
 
-def test_explain_risk_llm_called_when_shap_sufficient(client, demo_student, mock_openai, monkeypatch):
+def test_explain_risk_llm_called_when_shap_sufficient(client, demo_student, mock_anthropic, monkeypatch):
     """Als SHAP-waarden informatief zijn (max >= 0.01), wordt de LLM aangeroepen."""
     import numpy as np
 
@@ -199,10 +199,10 @@ def test_explain_risk_llm_called_when_shap_sufficient(client, demo_student, mock
         "imputed_columns": [],
     }
     client.post("/explain_risk", json=payload)
-    assert mock_openai.responses.create.called
+    assert mock_anthropic.messages.create.called
 
 
-def test_explain_risk_data_onvoldoende_skips_llm(client, demo_student, mock_openai):
+def test_explain_risk_data_onvoldoende_skips_llm(client, demo_student, mock_anthropic):
     """Als alle kolommen geïmputeerd zijn, wordt de LLM niet aangeroepen."""
     payload = {
         "student": demo_student,
@@ -212,11 +212,11 @@ def test_explain_risk_data_onvoldoende_skips_llm(client, demo_student, mock_open
     }
     resp = client.post("/explain_risk", json=payload)
     assert resp.status_code == 200
-    assert not mock_openai.responses.create.called
+    assert not mock_anthropic.messages.create.called
     assert "Geen gepersonaliseerd advies" in resp.json()["explanation"]
 
 
-def test_explain_risk_laag_risico(client, demo_student, mock_openai):
+def test_explain_risk_laag_risico(client, demo_student, mock_anthropic):
     payload = {
         "student": demo_student,
         "prediction": 0,

--- a/eduplan/uv.lock
+++ b/eduplan/uv.lock
@@ -951,25 +951,6 @@ wheels = [
 ]
 
 [[package]]
-name = "openai"
-version = "2.37.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/50/5901f01ef14e6c27788beb91e54fef5d6204fb5fb9e97402fc8a14de2e32/openai-2.37.0.tar.gz", hash = "sha256:f4bc562cc5f3a43d40d678105572d9d44765f6e0f50c125f63055419b72f4bd9", size = 754706, upload-time = "2026-05-15T22:30:35.428Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/4c/bce61680d0699a78a405fd9a67989b175ba020590428831aab2ab1d2be7c/openai-2.37.0-py3-none-any.whl", hash = "sha256:814633888b8f3b1ffd6615697c6e4ef93632d08b7c2e28c8c5ef3556e5a10107", size = 1303238, upload-time = "2026-05-15T22:30:32.767Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1670,7 +1651,6 @@ source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "fastapi" },
-    { name = "openai" },
     { name = "pandas" },
     { name = "pillow" },
     { name = "plotly" },
@@ -1696,7 +1676,6 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.43.0" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
-    { name = "openai", specifier = ">=2.26.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "plotly", specifier = ">=6.6.0" },

--- a/eduplan/uv.lock
+++ b/eduplan/uv.lock
@@ -47,6 +47,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.102.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/47/cb2a71f70431fb09af4db83e3ea89eb2dd8e0e348d27af53ed32e6c599dd/anthropic-0.102.0.tar.gz", hash = "sha256:96f747cad11886c4ae12d4080131b94eebd68b202bd2190fe27959031bb1fa9c", size = 763697, upload-time = "2026-05-13T18:12:41.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/75/0f6c603594876413bc858a00e7cc0d80a0cc14edf5c7b959a3ea6ec45e44/anthropic-0.102.0-py3-none-any.whl", hash = "sha256:ab96540bbd4b0f36564252d955a86f8abbe4f00944a24bc9931acc9b139bab6f", size = 763070, upload-time = "2026-05-13T18:12:43.474Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -253,6 +272,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -1640,6 +1668,7 @@ name = "streamlit-app-template"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "anthropic" },
     { name = "fastapi" },
     { name = "openai" },
     { name = "pandas" },
@@ -1664,6 +1693,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", specifier = ">=0.43.0" },
     { name = "fastapi", specifier = ">=0.135.1" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "openai", specifier = ">=2.26.0" },


### PR DESCRIPTION
## Summary

- Migrates all 3 eduplan backend LLM endpoints (`/summarize`, `/explain_risk`, `/map_columns`) from OpenAI Responses API to Anthropic Messages API using `claude-sonnet-4-6`.
- Drops `openai` dependency entirely; consolidates on `anthropic` (already used by `src/main.py` and `edupulse/`).
- `/map_columns` uses Anthropic's assistant-turn prefill (`{"role": "assistant", "content": "{"}`) for reliable JSON output.

## Approach

Incremental migration with both clients coexisting through Tasks 1–4 so the test suite stayed green at every checkpoint. Each endpoint migrated in its own commit with its tests swapped from `mock_openai` to `mock_anthropic`. Task 5 removed OpenAI entirely; Task 6 scrubbed stale docs.

Full migration plan: [`eduplan/docs/superpowers/plans/2026-05-18-anthropic-llm-migration.md`](eduplan/docs/superpowers/plans/2026-05-18-anthropic-llm-migration.md).

## Commits

| Commit | Description |
|--------|-------------|
| `51b36be` | Migration plan |
| `d169fec` | Anthropic alongside OpenAI (deps + dual conftest patch) |
| `a46f630` | `/summarize` → Anthropic |
| `b239e34` | `/map_columns` → Anthropic (assistant-prefill JSON) |
| `feb5a30` | `/explain_risk` → Anthropic |
| `89bf9b7` | Drop OpenAI dep + rename `anthropic_client` → `client` |
| `4c64286` | Docs: scrub OpenAI/GPT-4.1 references |
| `01989f3` | Fix start script `.env` loading + drop openai from requirements.txt |

## Test plan

- [x] `cd eduplan && uv run pytest tests/` — 38/38 pass
- [x] Real-API smoke test: `curl -X POST localhost:8000/summarize` returns HTTP 200 with idiomatic Dutch summary
- [x] Real-API smoke test: `curl -X POST localhost:8000/explain_risk` with high-absence student returns grounded EduPlan, no hallucinated values, rendered `<h2>`/`<h3>` headings
- [x] Dual-stage subagent review (spec compliance + code quality) per task; final whole-branch review approved

## Env vars

Only `ANTHROPIC_API_KEY` is now required for the eduplan backend (previously also needed `OPENAI_API_KEY`). The standalone Claude agent CLI in `eduplan/main.py` already used `ANTHROPIC_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)