### PR TITLE
eduplan: simplify start scripts (fixes #18)

### DIFF
--- a/eduplan/1_start_fastapi.sh
+++ b/eduplan/1_start_fastapi.sh
@@ -3,55 +3,37 @@
 
 set -e
 
-# cd "$(dirname "$0")" # Ensure we're in the script's directory
-
-echo
 echo
 echo "##################################################################"
 echo "#                                                                #"
-echo "#             EduPlan FastAPI backend                           #"
+echo "#             EduPlan FastAPI backend                            #"
 echo "#                                                                #"
 echo "##################################################################"
 echo
 
-
-# Initialize uv project if not present
 if [ ! -f "pyproject.toml" ]; then
-  echo "Project EduPlan niet gevonden. Aanmaken..."
-  uv init
-  echo "Project EduPlan geinitialiseerd"
+  echo "[FOUT] pyproject.toml niet gevonden — draai dit script vanuit de eduplan/ map."
+  exit 1
 fi
 
-# Create virtual environment if not present
-if [ ! -d ".venv" ]; then
-  echo "Virtual environment niet gevonden. Aanmaken..."
-  uv venv
-  echo "Virtual environment aangemaakt"
-fi
-
-# Activate virtual environment
-echo "Activeren van de virtual environment"
-source .venv/bin/activate
-echo "Omgeving geactiveerd"
-
-# Install dependencies
 echo "Installeren van dependencies..."
 uv sync
-
-echo
-echo "[START] Starting EduPlan FastAPI Server met uvicorn..."
-echo
-echo "Druk op Ctrl+C om de app te stoppen."
-echo
 
 # Laad .env zodat ANTHROPIC_API_KEY (en andere env vars) beschikbaar zijn voor de backend
 set -a
 [ -f .env ] && source .env
 set +a
 
-uvicorn --host "127.0.0.1" --port 8000 backend.main:app --reload
-RESULT=$?
-if [ $RESULT -ne 0 ]; then
+if [ -z "$ANTHROPIC_API_KEY" ]; then
   echo
-  echo "[FOUT] Er is een fout opgetreden bij het starten van de app."
+  echo "[WAARSCHUWING] ANTHROPIC_API_KEY is niet gezet — LLM-endpoints (/summarize, /explain_risk, /map_columns) zullen falen."
+  echo "Zet de key in .env of exporteer deze in je shell, en herstart het script."
+  echo
 fi
+
+echo
+echo "[START] Starting EduPlan FastAPI Server met uvicorn..."
+echo "Druk op Ctrl+C om de app te stoppen."
+echo
+
+uv run uvicorn --host 127.0.0.1 --port 8000 backend.main:app --reload

--- a/eduplan/2_start_streamlit.sh
+++ b/eduplan/2_start_streamlit.sh
@@ -1,46 +1,25 @@
 #!/usr/bin/env bash
 # Helper script to start the EduPlan Streamlit frontend using uv (Unix/Linux)
 
-# set -e
+set -e
 
-# cd "$(dirname "$0")" # Ensure we're in the script's directory
-echo
 echo
 echo "##################################################################"
 echo "#                                                                #"
-echo "#             EduPlan Streamlit frontend                        #"
+echo "#             EduPlan Streamlit frontend                         #"
 echo "#                                                                #"
 echo "##################################################################"
 echo
 
-
-# Initialize uv project if not present
 if [ ! -f "pyproject.toml" ]; then
-  echo "Project EduPlan niet gevonden. Aanmaken..."
-  uv init
-  echo "Project EduPlan geinitialiseerd"
-  echo "Virtual environment niet gevonden. Aanmaken..."
-  uv venv
-  echo "Virtual environment aangemaakt..."
+  echo "[FOUT] pyproject.toml niet gevonden — draai dit script vanuit de eduplan/ map."
+  exit 1
 fi
 
-# Create virtual environment if not present
-if [ ! -d ".venv" ]; then
-  echo "Virtual environment niet gevonden. Aanmaken..."
-  uv venv
-  echo "Virtual environment aangemaakt..."
-fi
-
-# Activate virtual environment
-echo "Activeren van de virtual environment"
-source .venv/bin/activate
-echo "Omgeving geactiveerd"
-
-# Install dependencies
 echo "Installeren van dependencies..."
 uv sync
 
-# Laad .env zodat ANTHROPIC_API_KEY (en andere env vars) beschikbaar zijn voor de frontend
+# Laad .env zodat env vars beschikbaar zijn voor de frontend
 set -a
 [ -f .env ] && source .env
 set +a
@@ -48,16 +27,11 @@ set +a
 echo
 echo "[START] Starting EduPlan Streamlit Server met uv..."
 echo "[INFO] De app opent automatisch in je browser op http://localhost:8502 of http://localhost:8503"
-echo
 echo "Druk op Ctrl+C om de app te stoppen."
 echo
 
-# Try first port (8502)
-uv run streamlit run --server.port 8502 frontend/app.py --server.headless false
-RESULT=$?
-if [ $RESULT -ne 0 ]; then
+if ! uv run streamlit run --server.port 8502 frontend/app.py --server.headless false; then
   echo
-  echo "[BUSY] De Streamlit server is niet gestart. Port 8502 wordt waarschijlijk al gebruikt."
-  echo "We proberen de Streamlit server te starten met port 8503."
+  echo "[BUSY] Port 8502 wordt waarschijnlijk al gebruikt — opnieuw proberen met port 8503."
   uv run streamlit run --server.port 8503 frontend/app.py --server.headless false
 fi


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update

## Description of Changes

Closes #18.

Removes defensive bootstrap-blokken die in praktijk meer kwaad dan goed deden:

- `uv init` fallback bij ontbrekende `pyproject.toml` → hard fail met duidelijke melding (clobberen voorkomen).
- `uv venv` fallback → overbodig; `uv sync` creëert de venv waar nodig.
- `source .venv/bin/activate` → overbodig; `uv run` regelt dit.
- Voeg `ANTHROPIC_API_KEY` presence-check toe aan de FastAPI start (vroeg luid falen ipv stil bij eerste API-call).

## Related Issues

Closes #18.

## Before / After

### Before

`1_start_fastapi.sh`: 58 regels, met `uv init` + `uv venv` + `source .venv/...` + `--reload` zonder `uv run`.
`2_start_streamlit.sh`: 64 regels met dezelfde bootstrap-blokken.

### After

`1_start_fastapi.sh`: 39 regels, `uv sync` → `.env` load → key-check → `uv run uvicorn`.
`2_start_streamlit.sh`: 37 regels, `uv sync` → `.env` load → `uv run streamlit` (met port 8503 fallback).

Totaal: -65 / +21 regels.

## Checklist

- [x] I have tested these changes locally (`uv run uvicorn --version` werkt; syntax-check `bash -n` op beide scripts)
- [x] My code follows the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)