### PR TITLE
edupulse: simplify-ceda cleanup pass

### DIFF
--- a/edupulse/backend/agent/harness.py
+++ b/edupulse/backend/agent/harness.py
@@ -1,7 +1,10 @@
 import hashlib
+import json
+import logging
 import time
 from collections import defaultdict
 from datetime import datetime, timezone
+
 from backend.models import AgentLogDB
 
 MAX_CALLS_PER_SESSIE = 60
@@ -59,9 +62,6 @@ class Harness:
         duur_ms: int,
         status: str = "ok",
     ):
-        import json
-        import logging
-
         input_str = str(inputs)
         input_hash = self._hash_pii(input_str)
         # Sla geen PII op in output_summary — alleen type en omvang van het resultaat.

--- a/edupulse/backend/agent/llm.py
+++ b/edupulse/backend/agent/llm.py
@@ -1,4 +1,3 @@
-# backend/agent/llm.py
 from abc import ABC, abstractmethod
 from typing import Any
 import anthropic

--- a/edupulse/backend/agent/tools.py
+++ b/edupulse/backend/agent/tools.py
@@ -1,4 +1,5 @@
-# backend/agent/tools.py
+from sqlalchemy import or_
+
 from backend.models import StudentDB, StudentSchema
 from backend.ml.predict import RisicoPredictor, DREMPEL
 
@@ -63,20 +64,20 @@ class ToolRegistry:
         self.db = db
         self.predictor = predictor
 
-    def _student_of_fout(self, studentnummer: str):
+    def _get_student_or_error(self, studentnummer: str) -> tuple[StudentDB | None, dict | None]:
         student = self.db.query(StudentDB).filter_by(studentnummer=studentnummer).first()
         if not student:
             return None, {"error": f"Student {studentnummer!r} niet gevonden."}
         return student, None
 
     def get_student_data(self, studentnummer: str) -> dict:
-        student, err = self._student_of_fout(studentnummer)
+        student, err = self._get_student_or_error(studentnummer)
         if err:
             return err
         return StudentSchema.model_validate(student).model_dump(mode="json")
 
     def predict_dropout_risk(self, studentnummer: str) -> dict:
-        student, err = self._student_of_fout(studentnummer)
+        student, err = self._get_student_or_error(studentnummer)
         if err:
             return err
         data = StudentSchema.model_validate(student).model_dump()
@@ -91,7 +92,7 @@ class ToolRegistry:
         }
 
     def get_cohort_comparison(self, studentnummer: str) -> dict:
-        student, err = self._student_of_fout(studentnummer)
+        student, err = self._get_student_or_error(studentnummer)
         if err:
             return err
         cohortgenoten = (
@@ -125,7 +126,7 @@ class ToolRegistry:
         }
 
     def get_mentor_info(self, studentnummer: str) -> dict:
-        student, err = self._student_of_fout(studentnummer)
+        student, err = self._get_student_or_error(studentnummer)
         if err:
             return err
         return {
@@ -136,8 +137,6 @@ class ToolRegistry:
         }
 
     def search_students(self, query: str) -> list[dict]:
-        from sqlalchemy import or_
-
         treffer = (
             self.db.query(StudentDB)
             .filter(

--- a/edupulse/backend/main.py
+++ b/edupulse/backend/main.py
@@ -1,9 +1,11 @@
-# backend/main.py
-import os
+import logging
 import uuid
 from contextlib import asynccontextmanager
+from pathlib import Path
+
 from fastapi import FastAPI, Depends, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from backend.database import get_db, engine, Base
@@ -21,9 +23,9 @@ from backend.agent.harness import Harness
 from backend.agent.kernel import AgentKernel
 from backend.ml.predict import RisicoPredictor, DREMPEL
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
-MODEL_PATH = os.path.join(DATA_DIR, "model.pkl")
-FEATURE_PATH = os.path.join(DATA_DIR, "feature_list.json")
+DATA_DIR = Path(__file__).parent.parent / "data"
+MODEL_PATH = DATA_DIR / "model.pkl"
+FEATURE_PATH = DATA_DIR / "feature_list.json"
 
 predictor: RisicoPredictor | None = None
 
@@ -32,8 +34,8 @@ predictor: RisicoPredictor | None = None
 async def lifespan(app: FastAPI):
     global predictor
     Base.metadata.create_all(bind=engine)
-    if os.path.exists(MODEL_PATH):
-        predictor = RisicoPredictor(model_path=MODEL_PATH, feature_path=FEATURE_PATH)
+    if MODEL_PATH.exists():
+        predictor = RisicoPredictor(model_path=str(MODEL_PATH), feature_path=str(FEATURE_PATH))
     app.state.llm = ClaudeLLMProvider()
     yield
 
@@ -64,6 +66,17 @@ def health():
 @app.get("/students", response_model=list[StudentSchema])
 def list_students(skip: int = 0, limit: int = 20, db: Session = Depends(get_db)):
     return db.query(StudentDB).offset(skip).limit(limit).all()
+
+
+@app.get("/students/search", response_model=list[StudentSchema])
+def search_students(q: str, limit: int = 10, db: Session = Depends(get_db)):
+    """Zoek studenten op (deel van) naam of studentnummer (case-insensitive)."""
+    return (
+        db.query(StudentDB)
+        .filter(or_(StudentDB.naam.ilike(f"%{q}%"), StudentDB.studentnummer.ilike(f"%{q}%")))
+        .limit(limit)
+        .all()
+    )
 
 
 @app.get("/students/{studentnummer}", response_model=StudentSchema)
@@ -119,8 +132,6 @@ def agent_chat(chat_request: ChatRequest, kernel: AgentKernel = Depends(_get_ker
     try:
         antwoord = kernel.run(chat_request.message, sessie_id=sessie_id)
     except Exception:
-        import logging
-
         logging.exception("Agent fout voor sessie %s", sessie_id)
         raise HTTPException(503, "Agent tijdelijk niet beschikbaar.")
     return ChatResponse(session_id=sessie_id, response=antwoord)

--- a/edupulse/backend/ml/predict.py
+++ b/edupulse/backend/ml/predict.py
@@ -1,5 +1,5 @@
-# backend/ml/predict.py
 import json
+
 import joblib
 import numpy as np
 import pandas as pd

--- a/edupulse/frontend/app.py
+++ b/edupulse/frontend/app.py
@@ -1,4 +1,3 @@
-# frontend/app.py
 import streamlit as st
 from streamlit_extras.bottom_container import bottom
 

--- a/edupulse/frontend/pages/geschiedenis.py
+++ b/edupulse/frontend/pages/geschiedenis.py
@@ -1,4 +1,3 @@
-# frontend/pages/geschiedenis.py
 import requests
 import streamlit as st
 

--- a/edupulse/frontend/pages/uitvalrisico.py
+++ b/edupulse/frontend/pages/uitvalrisico.py
@@ -1,4 +1,3 @@
-# frontend/pages/uitvalrisico.py
 import requests
 import streamlit as st
 from streamlit_extras.metric_cards import style_metric_cards
@@ -21,17 +20,14 @@ with st.sidebar:
     zoek = st.text_input("Naam of studentnummer", placeholder="Bijv. Youssef of 20240001")
     if zoek:
         try:
-            resp = requests.get(f"{API}/students?limit=100", timeout=10)
+            resp = requests.get(
+                f"{API}/students/search", params={"q": zoek, "limit": 8}, timeout=10
+            )
             resp.raise_for_status()
-            studenten = resp.json()
-            q = zoek.lower()
-            treffer = [s for s in studenten if q in s["naam"].lower() or q in s["studentnummer"]][
-                :8
-            ]
-            for s in treffer:
+            for s in resp.json():
                 if st.button(f"{s['naam']} ({s['studentnummer']})", key=s["studentnummer"]):
                     st.session_state.geselecteerde_student = s["studentnummer"]
-        except Exception:
+        except requests.RequestException:
             st.error("API niet bereikbaar. Start de backend eerst.")
 
 # Student kaart


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update

## Description of Changes

Findings van een 3-agent /simplify-ceda review (code-reuse + code-quality + efficiency) op de EduClaw Sprint 1 core. Implementeert alleen de surgical wins; bewust geskipt zijn de grotere refactors (parallel tool execution, app.state migration, LLMProvider ABC removal) — die vallen buiten Simplicity First.

### Functional bug

- `frontend/pages/uitvalrisico.py`: de sidebar-zoekfunctie deed `GET /students?limit=100` + client-side filter. Sinds de bulk-seed (~1000 studenten) brak dat stil — studenten met een match buiten de eerste 100 verschenen nooit in de resultaten. Vervangen door een nieuw `GET /students/search?q=...&limit=8` endpoint met server-side `ILIKE` over naam + studentnummer.

### Quality / style

- `backend/main.py`: `os.path` → `pathlib.Path` voor `DATA_DIR` / `MODEL_PATH` / `FEATURE_PATH`. Move `import logging` uit het `except` block naar module top.
- `backend/agent/tools.py`: rename `_student_of_fout` → `_get_student_or_error` (verb-first per CEDA-standaard), return type hint toegevoegd. Move `from sqlalchemy import or_` uit `search_students` naar module top.
- `backend/agent/harness.py`: move `import json` / `import logging` uit `_log` naar module top.
- Delete `# path/file.py` header comments uit 6 bestanden (pure WHAT-noise).

## Related Issues

Geen — opportunistische cleanup uitgevoerd via `/simplify-ceda`.

## Before / After

### Before

- Sidebar search miste studenten met match buiten eerste 100.
- 6 file-header comments met de path zelf als content.
- Lazy imports in 3 plekken.
- Cryptische `os.path.join(...)`.
- Tool helper niet verb-first.

### After

- Server-side search via dedicated endpoint, geen impliciete row-cap meer.
- Module-top imports overal.
- `pathlib.Path` consistent met de rest van het monorepo.
- Verb-first naming + type hint.

## Checklist

- [x] I have tested these changes locally (35/35 pytest, ruff format + check clean)
- [x] My code follows the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)