### PR TITLE
src: simplify-ceda cleanup pass on the template

### DIFF
--- a/src/backend/example_sales.py
+++ b/src/backend/example_sales.py
@@ -3,70 +3,69 @@ import random
 from datetime import datetime, timedelta
 from pathlib import Path
 
+import streamlit as st
+
 SALES_FILE = Path("data/sales.json")
 
 
-def generate_sample_sales():
+def generate_sample_sales() -> list[dict]:
     """Generate sample sales data if file doesn't exist."""
     categories = ["Electronics", "Clothing", "Books", "Home", "Sports"]
-    sales = []
-
     start_date = datetime.now() - timedelta(days=180)
-
-    for i in range(100):
-        date = start_date + timedelta(days=random.randint(0, 180))
-        sale = {
+    return [
+        {
             "id": i + 1,
-            "date": date.strftime("%Y-%m-%d"),
+            "date": (start_date + timedelta(days=random.randint(0, 180))).strftime("%Y-%m-%d"),
             "amount": round(random.uniform(50, 1000), 2),
             "category": random.choice(categories),
             "customer": f"Customer_{random.randint(1, 50)}",
         }
-        sales.append(sale)
+        for i in range(100)
+    ]
 
-    return sales
 
-
-def get_sales_data():
-    """Load or generate sales data."""
+@st.cache_data
+def get_sales_data() -> list[dict]:
+    """Load or generate sales data — cached across Streamlit reruns."""
     if not SALES_FILE.exists():
         SALES_FILE.parent.mkdir(parents=True, exist_ok=True)
         sales = generate_sample_sales()
         SALES_FILE.write_text(json.dumps(sales, indent=2), encoding="utf-8")
         return sales
-
     return json.loads(SALES_FILE.read_text(encoding="utf-8"))
 
 
-def calculate_sales_metrics(sales_data):
+def get_monthly_sales(sales_data: list[dict]) -> dict[str, float]:
+    """Sommeer omzet per maand (YYYY-MM-sleutel) — gebruikt voor chart en metrics."""
+    monthly: dict[str, float] = {}
+    for sale in sales_data:
+        month = sale["date"][:7]
+        monthly[month] = monthly.get(month, 0.0) + sale["amount"]
+    return monthly
+
+
+def calculate_sales_metrics(sales_data: list[dict]) -> dict[str, float | str]:
     """Calculate key sales metrics."""
     if not sales_data:
         return {"total": 0, "average": 0, "best_month": "N/A", "growth": 0}
 
     total = sum(sale["amount"] for sale in sales_data)
     average = total / len(sales_data)
-
-    monthly_totals: dict[str, float] = {}
-    for sale in sales_data:
-        month = sale["date"][:7]
-        monthly_totals[month] = monthly_totals.get(month, 0) + sale["amount"]
-
-    best_month = max(monthly_totals, key=monthly_totals.get) if monthly_totals else "N/A"
+    monthly_totals = get_monthly_sales(sales_data)
+    best_month = max(monthly_totals, key=lambda m: monthly_totals[m]) if monthly_totals else "N/A"
 
     months = sorted(monthly_totals.keys())
-    if len(months) >= 2:
-        growth = ((monthly_totals[months[-1]] - monthly_totals[months[0]]) / monthly_totals[months[0]]) * 100
-    else:
-        growth = 0
-
+    growth = (
+        ((monthly_totals[months[-1]] - monthly_totals[months[0]]) / monthly_totals[months[0]]) * 100
+        if len(months) >= 2
+        else 0
+    )
     return {"total": total, "average": average, "best_month": best_month, "growth": growth}
 
 
-def get_monthly_sales(sales_data):
-    """Get monthly sales data for charting."""
-    monthly_data: dict[str, float] = {}
+def get_sales_by_category(sales_data: list[dict]) -> dict[str, float]:
+    """Sommeer omzet per categorie — voor de bar chart in de Sales pagina."""
+    totals: dict[str, float] = {}
     for sale in sales_data:
-        month = sale["date"][:7]
-        monthly_data[month] = monthly_data.get(month, 0) + sale["amount"]
-
-    return monthly_data
+        totals[sale["category"]] = totals.get(sale["category"], 0.0) + sale["amount"]
+    return totals

--- a/src/backend/example_task.py
+++ b/src/backend/example_task.py
@@ -1,48 +1,50 @@
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 
 TASK_FILE = Path("data/tasks.json")
 
 
-def load_tasks():
+def load_tasks() -> list[dict]:
     """Load tasks from JSON file."""
     if not TASK_FILE.exists():
         TASK_FILE.parent.mkdir(parents=True, exist_ok=True)
         return []
-
     try:
         return json.loads(TASK_FILE.read_text(encoding="utf-8"))
-    except Exception:
+    except json.JSONDecodeError:
+        logging.exception("tasks.json is corrupt — terugvallen op lege lijst")
         return []
 
 
-def save_tasks(tasks):
+def save_tasks(tasks: list[dict]) -> None:
     """Save tasks to JSON file."""
     TASK_FILE.write_text(json.dumps(tasks, indent=2), encoding="utf-8")
 
 
-def add_task(title, description, priority):
+def add_task(title: str, description: str, priority: str) -> None:
     """Add a new task."""
     tasks = load_tasks()
-    new_task = {
-        "id": len(tasks) + 1,
-        "title": title,
-        "description": description,
-        "priority": priority,
-        "completed": False,
-        "created_at": datetime.now().isoformat(),
-    }
-    tasks.append(new_task)
+    tasks.append(
+        {
+            "id": len(tasks) + 1,
+            "title": title,
+            "description": description,
+            "priority": priority,
+            "completed": False,
+            "created_at": datetime.now().isoformat(),
+        }
+    )
     save_tasks(tasks)
 
 
-def get_tasks():
+def get_tasks() -> list[dict]:
     """Get all tasks."""
     return load_tasks()
 
 
-def update_task_status(task_id, completed):
+def update_task_status(task_id: int, completed: bool) -> None:
     """Update task completion status."""
     tasks = load_tasks()
     for task in tasks:
@@ -52,8 +54,7 @@ def update_task_status(task_id, completed):
     save_tasks(tasks)
 
 
-def delete_task(task_id):
+def delete_task(task_id: int) -> None:
     """Delete a task by ID."""
-    tasks = load_tasks()
-    tasks = [t for t in tasks if t["id"] != task_id]
+    tasks = [t for t in load_tasks() if t["id"] != task_id]
     save_tasks(tasks)

--- a/src/frontend/Files/example_Upload.py
+++ b/src/frontend/Files/example_Upload.py
@@ -49,10 +49,13 @@ if "file_bytes" in st.session_state:
     st.write(f"**File Size:** {st.session_state['file_size']} bytes")
 
     raw = st.session_state["file_bytes"]
-    if st.session_state["file_type"] == "text/plain":
-        content = raw.decode("utf-8")
-        st.text_area("Preview:", content, height=200)
-    else:
+    file_type = st.session_state["file_type"]
+    file_name = st.session_state["file_name"]
+    if file_type == "text/plain":
+        st.text_area("Preview:", raw.decode("utf-8"), height=200)
+    elif file_type in ("text/csv", "application/vnd.ms-excel") or file_name.endswith(".csv"):
         st.dataframe(parse_csv(raw))
+    else:
+        st.info(f"Voorbeeld niet beschikbaar voor bestandstype '{file_type or 'onbekend'}'.")
 else:
     st.info("No file uploaded yet")

--- a/src/frontend/Modules/example_Sales.py
+++ b/src/frontend/Modules/example_Sales.py
@@ -1,6 +1,11 @@
 import streamlit as st
 
-from backend.example_sales import calculate_sales_metrics, get_monthly_sales, get_sales_data
+from backend.example_sales import (
+    calculate_sales_metrics,
+    get_monthly_sales,
+    get_sales_by_category,
+    get_sales_data,
+)
 
 # ---------------------------------------
 # PAGE CONFIGURATION
@@ -12,7 +17,6 @@ icon = ":material/euro:"
 # PAGE ELEMENTS
 # ---------------------------------------
 st.title("📈 Sales Dashboard")
-st.balloons()
 
 # Get data
 sales_data = get_sales_data()
@@ -31,19 +35,11 @@ with col4:
 
 # Monthly sales chart
 st.subheader("Monthly Sales Trend")
-monthly_data = get_monthly_sales(sales_data)
-st.line_chart(monthly_data)
+st.line_chart(get_monthly_sales(sales_data))
 
 # Sales by category
 st.subheader("Sales by Category")
-category_data = {}
-for sale in sales_data:
-    category = sale["category"]
-    if category not in category_data:
-        category_data[category] = 0
-    category_data[category] += sale["amount"]
-
-st.bar_chart(category_data)
+st.bar_chart(get_sales_by_category(sales_data))
 
 # Raw data table
 if st.checkbox("Show detailed sales data"):

--- a/src/frontend/Modules/example_Task.py
+++ b/src/frontend/Modules/example_Task.py
@@ -12,18 +12,17 @@ icon = ":material/folder:"
 # PAGE ELEMENTS
 # ---------------------------------------
 st.title("✅ Task Manager")
-st.balloons()
 
 # Add new task
 st.subheader("Add New Task")
 with st.form("add_task"):
-    title = st.text_input("Task Title")
+    task_title = st.text_input("Task Title")
     description = st.text_area("Description")
     priority = st.selectbox("Priority", ["Low", "Medium", "High"])
 
     if st.form_submit_button("Add Task"):
-        if title:
-            add_task(title, description, priority)
+        if task_title:
+            add_task(task_title, description, priority)
             st.success("Task added successfully!")
         else:
             st.error("Please enter a task title")
@@ -34,6 +33,8 @@ tasks = get_tasks()
 
 if not tasks:
     st.info("No tasks yet. Add one above!")
+
+PRIORITY_COLOR = {"High": "🔴", "Medium": "🟡", "Low": "🟢"}
 
 for task in tasks:
     with st.container():
@@ -48,8 +49,7 @@ for task in tasks:
                 st.write(f"*{task['description']}*")
 
         with col2:
-            color = {"High": "🔴", "Medium": "🟡", "Low": "🟢"}
-            st.write(color.get(task["priority"], "") + task["priority"])
+            st.write(PRIORITY_COLOR.get(task["priority"], "") + task["priority"])
 
         with col3:
             if st.button("Toggle", key=f"toggle_{task['id']}"):

--- a/src/frontend/Overview/Home.py
+++ b/src/frontend/Overview/Home.py
@@ -1,4 +1,3 @@
-# Home.py
 import streamlit as st
 
 title = "Home"

--- a/src/main.py
+++ b/src/main.py
@@ -39,12 +39,30 @@ class Tool(BaseModel):
     input_schema: dict[str, Any]
 
 
+MODEL = "claude-sonnet-4-5-20250929"
+MAX_AGENT_ITERATIONS = 25
+
+
 class AIAgent:
     def __init__(self, api_key: str):
         self.client = Anthropic(api_key=api_key)
         self.messages: list[dict[str, Any]] = []
         self.tools: list[Tool] = []
+        # Beperk tools tot het huidige werk-directory om path-traversal te voorkomen.
+        # Een door het model voorgesteld pad wordt resolved binnen deze root.
+        self.workspace = Path.cwd().resolve()
         self._setup_tools()
+
+    def _safe_path(self, user_path: str) -> Path:
+        """Resolveer een door het model aangegeven pad binnen self.workspace.
+
+        Voorkomt dat het model bestanden buiten de werkmap leest of schrijft via
+        absolute paden (/etc/passwd) of '..'-traversal.
+        """
+        candidate = (self.workspace / user_path).resolve()
+        if not candidate.is_relative_to(self.workspace):
+            raise PermissionError(f"Pad buiten workspace ({self.workspace}): {user_path}")
+        return candidate
 
     def _setup_tools(self):
         self.tools = [
@@ -121,50 +139,53 @@ class AIAgent:
 
     def _read_file(self, path: str) -> str:
         try:
-            content = Path(path).read_text(encoding="utf-8")
+            p = self._safe_path(path)
+            content = p.read_text(encoding="utf-8")
             return f"File contents of {path}:\n{content}"
+        except PermissionError as e:
+            return f"Access denied: {e}"
         except FileNotFoundError:
             return f"File not found: {path}"
-        except Exception as e:
-            return f"Error reading file: {str(e)}"
+        except OSError as e:
+            return f"Error reading file: {e}"
 
     def _list_files(self, path: str) -> str:
         try:
-            p = Path(path)
+            p = self._safe_path(path)
             if not p.exists():
                 return f"Path not found: {path}"
 
             items = []
             for entry in sorted(p.iterdir(), key=lambda x: x.name):
-                if entry.is_dir():
-                    items.append(f"[DIR]  {entry.name}/")
-                else:
-                    items.append(f"[FILE] {entry.name}")
+                marker = "[DIR] " if entry.is_dir() else "[FILE]"
+                suffix = "/" if entry.is_dir() else ""
+                items.append(f"{marker} {entry.name}{suffix}")
 
             if not items:
                 return f"Empty directory: {path}"
 
             return f"Contents of {path}:\n" + "\n".join(items)
-        except Exception as e:
-            return f"Error listing files: {str(e)}"
+        except PermissionError as e:
+            return f"Access denied: {e}"
+        except OSError as e:
+            return f"Error listing files: {e}"
 
     def _edit_file(self, path: str, old_text: str, new_text: str) -> str:
         try:
-            p = Path(path)
+            p = self._safe_path(path)
             if p.exists() and old_text:
                 content = p.read_text(encoding="utf-8")
-
                 if old_text not in content:
                     return f"Text not found in file: {old_text}"
-
                 p.write_text(content.replace(old_text, new_text), encoding="utf-8")
                 return f"Successfully edited {path}"
-            else:
-                p.parent.mkdir(parents=True, exist_ok=True)
-                p.write_text(new_text, encoding="utf-8")
-                return f"Successfully created {path}"
-        except Exception as e:
-            return f"Error editing file: {str(e)}"
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(new_text, encoding="utf-8")
+            return f"Successfully created {path}"
+        except PermissionError as e:
+            return f"Access denied: {e}"
+        except OSError as e:
+            return f"Error editing file: {e}"
 
     def chat(self, user_input: str) -> str:
         logging.info(f"User input: {user_input}")
@@ -179,53 +200,52 @@ class AIAgent:
             for tool in self.tools
         ]
 
-        while True:
+        for _ in range(MAX_AGENT_ITERATIONS):
             try:
                 response = self.client.messages.create(
-                    model="claude-sonnet-4-5-20250929",
+                    model=MODEL,
                     max_tokens=4096,
                     system="You are a helpful coding assistant operating in a terminal environment. Output only plain text without markdown formatting, as your responses appear directly in the terminal. Be concise but thorough, providing clear and practical advice with a friendly tone. Don't use any asterisk characters in your responses.",
                     messages=self.messages,
                     tools=tool_schemas,
                 )
-
-                assistant_message = {"role": "assistant", "content": []}
-
-                for content in response.content:
-                    if content.type == "text":
-                        assistant_message["content"].append({"type": "text", "text": content.text})
-                    elif content.type == "tool_use":
-                        assistant_message["content"].append(
-                            {
-                                "type": "tool_use",
-                                "id": content.id,
-                                "name": content.name,
-                                "input": content.input,
-                            }
-                        )
-
-                self.messages.append(assistant_message)
-
-                tool_results = []
-                for content in response.content:
-                    if content.type == "tool_use":
-                        result = self._execute_tool(content.name, content.input)
-                        logging.info(f"Tool result: {result[:500]}...")
-                        tool_results.append(
-                            {
-                                "type": "tool_result",
-                                "tool_use_id": content.id,
-                                "content": result,
-                            }
-                        )
-
-                if tool_results:
-                    self.messages.append({"role": "user", "content": tool_results})
-                else:
-                    return response.content[0].text if response.content else ""
-
             except Exception as e:
                 return f"Error: {str(e)}"
+
+            assistant_message = {"role": "assistant", "content": []}
+            for content in response.content:
+                if content.type == "text":
+                    assistant_message["content"].append({"type": "text", "text": content.text})
+                elif content.type == "tool_use":
+                    assistant_message["content"].append(
+                        {
+                            "type": "tool_use",
+                            "id": content.id,
+                            "name": content.name,
+                            "input": content.input,
+                        }
+                    )
+            self.messages.append(assistant_message)
+
+            tool_results = []
+            for content in response.content:
+                if content.type == "tool_use":
+                    result = self._execute_tool(content.name, content.input)
+                    logging.info(f"Tool result: {result[:500]}...")
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": content.id,
+                            "content": result,
+                        }
+                    )
+
+            if not tool_results:
+                # Geen tool-call meer: pak alle text-blocks van het assistant antwoord.
+                return "".join(b.text for b in response.content if b.type == "text")
+            self.messages.append({"role": "user", "content": tool_results})
+
+        return f"[Agent stopte na {MAX_AGENT_ITERATIONS} iteraties zonder eindantwoord.]"
 
 
 def main():


### PR DESCRIPTION
## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Documentation update

## Description of Changes

3-agent `/simplify-ceda` review op de `src/` Streamlit template (root van de monorepo). Het is een TEMPLATE — bugs/anti-patterns die hier blijven staan worden meegekopieerd naar elk afgeleid project. Daarom een agressievere pass dan op productiecode.

### Security / correctness — `src/main.py` (Claude agent CLI)

- **Path-traversal fix.** De file-tools accepteerden elk pad (`/etc/passwd`, `../../.bashrc`). Nu confined to a workspace root (`Path.cwd().resolve()` at startup); `_safe_path()` verifieert `is_relative_to(workspace)` voordat I/O start.
- **Unbounded loop fix.** `while True:` in `chat()` had geen iteratie-cap; vervangen door `for _ in range(MAX_AGENT_ITERATIONS)` met een nette eindmelding.
- **Tekst-extractie fix.** `response.content[0].text` crashte als het eerste block een `tool_use` was. Nu: `"".join(b.text for b in response.content if b.type == "text")`.
- **Narrow excepts** op file tools (`OSError`, `PermissionError` ipv `Exception`); model-id naar een `MODEL` constant.

### Bug fixes in example pages

- **`example_Task.py`**: form-input `title = st.text_input(...)` overschreef de module-level `title` (de page-registration variabele die `st.navigation` leest). Hernoemd naar `task_title`.
- **`example_Upload.py`**: CSV-fallback liep door voor elk niet-text mime-type. PDFs/images crashten in `pandas.read_csv`. Nu expliciete mime-check + `.csv`-extensie-check + nette "preview niet beschikbaar" melding.

### Template-as-teacher improvements

- `@st.cache_data` op `get_sales_data` — de Home-pagina preekt het pattern, de Sales-pagina liet het zien noch gebruiken.
- DRY: maand-aggregatie geëxtraheerd naar `get_monthly_sales`; nieuwe `get_sales_by_category` zodat de Sales-pagina geen computation meer in de UI heeft (per CLAUDE.md).
- Type hints op alle example-functie-signatures (template moet typing demonstreren).
- Narrow `json.JSONDecodeError` + `logging.exception()` in `load_tasks` ipv `except Exception`.

### Cleanup

- `st.balloons()` weg uit twee CRUD-pages (rerun-noise).
- Stray `# Home.py` header comment weg.
- `PRIORITY_COLOR` dict gehoist uit de per-task render-loop.

## Test plan

- [x] Ruff format + check clean op alle 7 gewijzigde files.
- [x] Smoke-test op `_safe_path`: in-workspace paden werken, `../../../etc/passwd` en `/etc/passwd` worden geweigerd, nonexistent files geven nette melding.
- [x] AST-parse OK voor alle 7 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)