### PR TITLE
feat: stream EduPlan-begeleidingssecties voor snellere ervaring

### DIFF
--- a/eduplan/backend/main.py
+++ b/eduplan/backend/main.py
@@ -42,6 +42,7 @@ import yaml
 from anthropic import Anthropic
 from dotenv import load_dotenv
 from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sklearn.ensemble import RandomForestRegressor
 
@@ -529,8 +530,24 @@ def rank_students(request: RankRequest):
     return result
 
 
-@app.post("/explain_risk")
-def explain_risk(request: ExplainRequest):
+# Getoond wanneer alle SHAP-waarden ~0 zijn: geen enkele kolom leverde informatie op,
+# dus gepersonaliseerd advies is niet mogelijk en het LLM wordt overgeslagen.
+_DATA_ONVOLDOENDE_HTML = (
+    "<br><b>⚠️ Geen gepersonaliseerd advies mogelijk</b><br>"
+    "De geüploade kolommen bevatten te weinig informatie die het model herkent. "
+    "Het model heeft geen variatie kunnen detecteren ten opzichte van de gemiddelde student. "
+    "Controleer of uw databestand de juiste kolommen bevat (zoals verzuim, leeftijd, "
+    "vooropleiding en aanmeldingshistorie) en upload opnieuw."
+)
+
+
+def _prepare_explanation(request: ExplainRequest) -> tuple[str, str | None]:
+    """Bouw Sectie 1 (deterministisch) en de LLM-prompt voor secties 2–4.
+
+    Gedeeld door `/explain_risk` (blokkerend) en `/explain_risk_stream` (streaming).
+    Geeft `(sectie1_html, prompt)` terug; `prompt` is None wanneer de data onvoldoende
+    is voor gepersonaliseerd advies (dan moet het LLM worden overgeslagen).
+    """
     student = request.student
     probability = request.probability
 
@@ -572,20 +589,8 @@ def explain_risk(request: ExplainRequest):
         data_onvoldoende=data_onvoldoende,
     )
 
-    # ── Sectie 2–4: LLM schrijft alleen begeleidingsadvies ───────────────────
-    # Als alle SHAP-waarden ~0 zijn, heeft geen enkele kolom informatie opgeleverd.
-    # In dat geval is gepersonaliseerd advies niet mogelijk.
     if data_onvoldoende:
-        return {
-            "explanation": sectie1
-            + (
-                "<br><b>⚠️ Geen gepersonaliseerd advies mogelijk</b><br>"
-                "De geüploade kolommen bevatten te weinig informatie die het model herkent. "
-                "Het model heeft geen variatie kunnen detecteren ten opzichte van de gemiddelde student. "
-                "Controleer of uw databestand de juiste kolommen bevat (zoals verzuim, leeftijd, "
-                "vooropleiding en aanmeldingshistorie) en upload opnieuw."
-            )
-        }
+        return sectie1, None
 
     # Het LLM krijgt UITSLUITEND de SHAP-factoren en het risiconiveau.
     # Binaire features worden ondubbelzinnig gelabeld (ja/nee) zodat het LLM
@@ -637,6 +642,17 @@ Maximaal 5 genummerde actiepunten, gesorteerd op urgentie.
 Maak expliciet onderscheid: déze week vs déze maand.
 """
 
+    return sectie1, prompt
+
+
+@app.post("/explain_risk")
+def explain_risk(request: ExplainRequest):
+    sectie1, prompt = _prepare_explanation(request)
+
+    # Als alle SHAP-waarden ~0 zijn, heeft geen enkele kolom informatie opgeleverd.
+    if prompt is None:
+        return {"explanation": sectie1 + _DATA_ONVOLDOENDE_HTML}
+
     sectie2_4 = _call_llm(prompt, max_tokens=2048, temperature=0.2)
 
     # Converteer markdown naar HTML zodat de frontend het correct kan renderen
@@ -644,6 +660,43 @@ Maak expliciet onderscheid: déze week vs déze maand.
 
     # Sectie 1 (deterministisch HTML) + sectie 2-4 (LLM) samenvoegen
     return {"explanation": sectie1 + sectie2_4_html}
+
+
+@app.post("/explain_risk_stream")
+def explain_risk_stream(request: ExplainRequest):
+    """Streamende variant van /explain_risk.
+
+    Stuurt NDJSON-regels zodat de frontend Sectie 1 direct kan tonen en de
+    begeleidingssecties token-voor-token kan laten verschijnen:
+      {"type":"section1","html": ...}      — direct, deterministisch
+      {"type":"warning","html": ...}       — bij onvoldoende data (geen LLM)
+      {"type":"delta","text": ...}         — ruwe markdown-chunk per LLM-delta
+      {"type":"final_html","html": ...}    — markdown→HTML van de volledige tekst
+    """
+    sectie1, prompt = _prepare_explanation(request)
+
+    def _gen():
+        yield json.dumps({"type": "section1", "html": sectie1}) + "\n"
+
+        if prompt is None:
+            yield json.dumps({"type": "warning", "html": _DATA_ONVOLDOENDE_HTML}) + "\n"
+            return
+
+        stukken: list[str] = []
+        with client.messages.stream(
+            model=ANTHROPIC_MODEL,
+            max_tokens=2048,
+            temperature=0.2,
+            messages=[{"role": "user", "content": prompt}],
+        ) as stream:
+            for tekst in stream.text_stream:
+                stukken.append(tekst)
+                yield json.dumps({"type": "delta", "text": tekst}) + "\n"
+
+        # Conversie markdown→HTML blijft de single source of truth in de backend.
+        yield json.dumps({"type": "final_html", "html": _markdown_to_html("".join(stukken))}) + "\n"
+
+    return StreamingResponse(_gen(), media_type="application/x-ndjson")
 
 
 @app.post("/feature_importance")

--- a/eduplan/docs/superpowers/specs/2026-06-01-eduplan-streaming-design.md
+++ b/eduplan/docs/superpowers/specs/2026-06-01-eduplan-streaming-design.md
@@ -1,0 +1,57 @@
+# EduPlan streaming — design
+
+**Datum:** 2026-06-01
+**Doel:** Het genereren van een EduPlan voelt traag omdat de UI blanco blijft tot één
+blokkerende LLM-call (~2048 tokens, ~8–20s) klaar is. We tonen Sectie 1
+(deterministisch, SHAP = 0.2ms) direct en streamen secties 2–4 token-voor-token.
+
+## Waarom dit werkt
+
+De volledige wachttijd is één `client.messages.create`. Sectie 1 is deterministisch
+maar wacht nu achter het LLM. Gemeten: SHAP op één rij = 0.2ms; explainer wordt bij
+startup gebouwd. Eerste content kan dus in ~1s verschijnen i.p.v. na de hele generatie.
+
+## Backend (`backend/main.py`)
+
+1. **Refactor** gedeelde logica uit `explain_risk` naar een helper:
+   `_prepare_explanation(request) -> (sectie1_html, prompt | None, data_onvoldoende)`.
+   Doet risiconiveau, SHAP, top_factors, `data_onvoldoende`, Sectie 1 HTML en de prompt.
+2. **Behoud** `POST /explain_risk` ongewijzigd qua gedrag (tests + non-streaming fallback);
+   roept nu de helper aan.
+3. **Nieuw** `POST /explain_risk_stream` → `StreamingResponse` van **NDJSON**-regels:
+   - `{"type":"section1","html": <sectie1>}` — direct
+   - bij `data_onvoldoende`: `{"type":"warning","html": ...}` en klaar (geen LLM)
+   - anders `client.messages.stream(...)` en per delta `{"type":"delta","text": <ruwe markdown>}`
+   - na de deltas: `{"type":"final_html","html": <_markdown_to_html(volledige tekst)>}`
+     zodat markdown→HTML-conversie de single source of truth in de backend blijft.
+
+## Frontend (`frontend/app.py`, `_genereer_eduplan`)
+
+Streaming-render draait op de **main script thread** (`st.*` vanuit een ThreadPool-worker
+rendert stil niets).
+
+1. Start `_fetch_fi()` in een thread *vóór* het streamen, `.result()` erna — blijft
+   concurrent, geen `st.*` in de worker.
+2. POST naar `/explain_risk_stream` met `stream=True`, itereer NDJSON via `iter_lines()`:
+   - `section1` → render één keer in de bestaande styled HTML-wrapper
+   - generator van `delta`-`text` → `full = st.write_stream(gen)` (transient markdown — prima)
+   - `warning` → render, geen stream
+   - `final_html` → bewaren
+3. Na de stream: `explanation = sectie1_html + final_html`, docx bouwen, `st.rerun()` →
+   `_render_eduplan_content` toont de definitieve gestylede versie.
+
+## Error handling
+
+- Connectiefout / non-200 → bestaande `_error_html`-pad, opslaan als `explanation`, rerun.
+- `data_onvoldoende` → `warning`-regel, geen LLM.
+
+## Testing
+
+- Nieuwe test voor `/explain_risk_stream`: mock `client.messages.stream` (context manager
+  die delta-events levert) — andere vorm dan de bestaande `mock_anthropic` (`messages.create`).
+  Nieuwe fixture `mock_anthropic_stream` in `conftest.py`.
+- Bestaande `/explain_risk`-tests blijven groen.
+
+## Scope
+
+Twee bestanden + één conftest-fixture + één test. Oud endpoint en docx-flow onaangetast.

--- a/eduplan/frontend/app.py
+++ b/eduplan/frontend/app.py
@@ -25,6 +25,7 @@
 # ─────────────────────────────────────────────
 
 import html
+import json
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
@@ -86,9 +87,9 @@ _defaults = {
     "laatste_analyse": None,
     "eduplan_genereren": False,
     "geselecteerde_student": 0,
-    "trainings_df": None,        # historische data met Dropout-kolom (voor training)
+    "trainings_df": None,  # historische data met Dropout-kolom (voor training)
     "trainings_filename": "",
-    "predictie_df": None,        # huidig cohort zonder Dropout (voor ranking)
+    "predictie_df": None,  # huidig cohort zonder Dropout (voor ranking)
     "predictie_filename": "",
     "gebruik_demo_data": True,
     "toon_alle_opleidingen": False,
@@ -220,8 +221,7 @@ def _feedback_upload(filename: str, n: int, hernoem_log: dict, vul_log: list) ->
         regels.append(f"**Kolommen automatisch gekoppeld:** {koppelingen}")
     if vul_log:
         regels.append(
-            "**Kolommen niet gevonden, aangevuld met standaardwaarden:** "
-            + ", ".join(f"`{c}`" for c in vul_log)
+            "**Kolommen niet gevonden, aangevuld met standaardwaarden:** " + ", ".join(f"`{c}`" for c in vul_log)
         )
     if hernoem_log or vul_log:
         st.info("\n\n".join(regels))
@@ -238,12 +238,17 @@ def _verwerk_trainingsdata(uploaded_file) -> None:
             # Detecteer uitvalkolom onder alternatieve naam
             if "Dropout" not in new_df.columns:
                 _synoniemen = {
-                    "dropout", "uitval", "uitgevallen", "uitgevalen", "isuitgevallen",
-                    "uitvalindicator", "uitval_indicator", "gestopt", "vroegtijdigverlaten",
+                    "dropout",
+                    "uitval",
+                    "uitgevallen",
+                    "uitgevalen",
+                    "isuitgevallen",
+                    "uitvalindicator",
+                    "uitval_indicator",
+                    "gestopt",
+                    "vroegtijdigverlaten",
                 }
-                _gevonden = next(
-                    (c for c in new_df.columns if _norm_col(c) in _synoniemen), None
-                )
+                _gevonden = next((c for c in new_df.columns if _norm_col(c) in _synoniemen), None)
                 if _gevonden is None:
                     try:
                         resp = requests.post(
@@ -400,110 +405,139 @@ def _genereer_eduplan():
     row, result = risico[idx]
     naam = row["Naam"]
 
-    with st.spinner(f"🕑 Bezig met genereren van het EduPlan voor {naam}…"):
-        gebruik_default = st.session_state.gebruik_demo_data
-        vul_log = st.session_state.get("vul_log", [])
-        vul_set = set(vul_log)
+    gebruik_default = st.session_state.gebruik_demo_data
+    vul_log = st.session_state.get("vul_log", [])
+    vul_set = set(vul_log)
 
-        def _error_html(title: str, detail: str) -> str:
-            return (
-                "<div style='border-left:4px solid #c0392b; background:#fdf3f1; "
-                "padding:14px 18px; border-radius:6px;'>"
-                f"<b style='color:#c0392b;'>⚠️ {html.escape(title)}</b><br>"
-                f"<span style='color:#444;'>{html.escape(detail)}</span>"
-                "</div>"
+    def _error_html(title: str, detail: str) -> str:
+        return (
+            "<div style='border-left:4px solid #c0392b; background:#fdf3f1; "
+            "padding:14px 18px; border-radius:6px;'>"
+            f"<b style='color:#c0392b;'>⚠️ {html.escape(title)}</b><br>"
+            f"<span style='color:#444;'>{html.escape(detail)}</span>"
+            "</div>"
+        )
+
+    def _fetch_fi():
+        # Stille fallback naar {}: feature importance voedt een ondersteunende
+        # bar chart die zelf gracefully omgaat met een lege dict. Een fout hier
+        # mag het hoofd-EduPlan niet overschaduwen.
+        try:
+            resp = requests.post(
+                "http://localhost:8000/feature_importance",
+                json={
+                    "student": row.to_dict(),
+                    "use_default_model": gebruik_default,
+                },
+                timeout=10,
             )
-
-        def _fetch_explain():
-            try:
-                resp = requests.post(
-                    "http://localhost:8000/explain_risk",
-                    json={
-                        "student": row.to_dict(),
-                        "prediction": result["prediction"],
-                        "probability": result["probability"],
-                        "use_default_model": gebruik_default,
-                        "imputed_columns": vul_log,
-                    },
-                    timeout=60,
-                )
-            except requests.Timeout:
-                return _error_html(
-                    "Time-out bij genereren EduPlan",
-                    "De backend reageerde niet binnen 60 seconden. Mogelijk is het LLM-model traag of de Anthropic API onbereikbaar.",
-                )
-            except requests.ConnectionError:
-                return _error_html(
-                    "Backend niet bereikbaar",
-                    "Geen verbinding met http://localhost:8000. Controleer of de FastAPI backend draait (./1_start_fastapi.sh).",
-                )
-            except requests.RequestException as e:
-                return _error_html("Netwerkfout", str(e))
-
             if resp.status_code != 200:
-                snippet = resp.text[:300] if resp.text else "(geen response body)"
-                return _error_html(
-                    f"Backend fout (HTTP {resp.status_code})",
-                    f"Het /explain_risk endpoint gaf een fout terug. Bekijk de backend-log voor details. Response: {snippet}",
-                )
-
-            try:
-                return resp.json()["explanation"]
-            except (ValueError, KeyError) as e:
-                return _error_html(
-                    "Onverwachte response van backend",
-                    f"De response bevatte geen geldige JSON met 'explanation' veld: {e}",
-                )
-
-        def _fetch_fi():
-            # Stille fallback naar {}: feature importance voedt een ondersteunende
-            # bar chart die zelf gracefully omgaat met een lege dict. Een fout hier
-            # mag het hoofd-EduPlan (van _fetch_explain) niet overschaduwen.
-            try:
-                resp = requests.post(
-                    "http://localhost:8000/feature_importance",
-                    json={
-                        "student": row.to_dict(),
-                        "use_default_model": gebruik_default,
-                    },
-                    timeout=10,
-                )
-                if resp.status_code != 200:
-                    return {}
-                return resp.json().get("feature_importance", {})
-            except (requests.RequestException, ValueError):
                 return {}
+            return resp.json().get("feature_importance", {})
+        except (requests.RequestException, ValueError):
+            return {}
 
-        with ThreadPoolExecutor(max_workers=2) as pool:
-            f_exp = pool.submit(_fetch_explain)
-            f_fi = pool.submit(_fetch_fi)
-            exp = f_exp.result()
-            fi_dict = f_fi.result()
+    # Feature importance loopt concurrent in een thread (geen st.* erin, dus veilig
+    # buiten de main-thread); de streaming-render hieronder MOET op de main thread.
+    pool = ThreadPoolExecutor(max_workers=1)
+    f_fi = pool.submit(_fetch_fi)
 
-        fi_str = ", ".join(f"{k}: {v:.2f}" for k, v in fi_dict.items()) if fi_dict else "Niet beschikbaar."
+    # Styled wrapper die overeenkomt met de definitieve render (_render_eduplan_content).
+    _WRAP = (
+        '<div style=\'font-family:"General Sans",sans-serif; font-size:15px; '
+        "line-height:1.85; background:white; border-radius:16px; padding:28px 32px;'>"
+    )
 
-        def _safe_value(col: str, cast_fn):
-            if col in vul_set or col not in row.index:
-                return "niet beschikbaar"
-            return cast_fn(row[col])
+    # ── Stream: Sectie 1 direct, secties 2–4 token-voor-token ─────────────────
+    profiel_ph = st.empty()  # reserveert een slot vóór de streamende tekst
+    captured = {"section1": None, "final_html": None, "warning": None}
+    exp = None
 
-        analyse = {
-            "naam": naam,
-            "opleiding": row.get("Opleiding", "—"),
-            "klas": row.get("Klas", "—"),
-            "mentor": row.get("Mentor", "—"),
-            "studentnummer": int(row["Studentnummer"]) if "Studentnummer" in row.index else "—",
-            "leeftijd": _safe_value("StudentAge", int),
-            "ongeoorloofd_verzuim": _safe_value("absence_unauthorized", float),
-            "geoorloofd_verzuim": _safe_value("absence_authorized", float),
-            "probability": result["probability"],
-            "explanation": exp,
-            "feature_importance": fi_str,
-            "feature_importance_dict": fi_dict,
-        }
-        analyse["docx"] = _build_word_doc(analyse)
-        st.session_state.laatste_analyse = analyse
-        st.session_state.eduplan_genereren = False
+    def _delta_gen():
+        for raw in resp.iter_lines(decode_unicode=True):
+            if not raw:
+                continue
+            msg = json.loads(raw)
+            soort = msg["type"]
+            if soort == "section1":
+                captured["section1"] = msg["html"]
+                profiel_ph.markdown(_WRAP + msg["html"] + "</div>", unsafe_allow_html=True)
+            elif soort == "warning":
+                captured["warning"] = msg["html"]
+            elif soort == "delta":
+                yield msg["text"]
+            elif soort == "final_html":
+                captured["final_html"] = msg["html"]
+
+    try:
+        resp = requests.post(
+            "http://localhost:8000/explain_risk_stream",
+            json={
+                "student": row.to_dict(),
+                "prediction": result["prediction"],
+                "probability": result["probability"],
+                "use_default_model": gebruik_default,
+                "imputed_columns": vul_log,
+            },
+            stream=True,
+            timeout=60,
+        )
+        if resp.status_code != 200:
+            snippet = resp.text[:300] if resp.text else "(geen response body)"
+            exp = _error_html(
+                f"Backend fout (HTTP {resp.status_code})",
+                f"Het /explain_risk_stream endpoint gaf een fout terug. Bekijk de backend-log voor details. Response: {snippet}",
+            )
+        else:
+            st.write_stream(_delta_gen())
+            if captured["warning"] is not None:
+                exp = (captured["section1"] or "") + captured["warning"]
+            elif captured["final_html"] is not None:
+                exp = (captured["section1"] or "") + captured["final_html"]
+            else:
+                exp = _error_html(
+                    "Onverwachte response van backend",
+                    "De stream eindigde zonder volledige begeleidingstekst (geen final_html).",
+                )
+    except requests.Timeout:
+        exp = _error_html(
+            "Time-out bij genereren EduPlan",
+            "De backend reageerde niet binnen 60 seconden. Mogelijk is het LLM-model traag of de Anthropic API onbereikbaar.",
+        )
+    except requests.ConnectionError:
+        exp = _error_html(
+            "Backend niet bereikbaar",
+            "Geen verbinding met http://localhost:8000. Controleer of de FastAPI backend draait (./1_start_fastapi.sh).",
+        )
+    except requests.RequestException as e:
+        exp = _error_html("Netwerkfout", str(e))
+
+    fi_dict = f_fi.result()
+    pool.shutdown()
+    fi_str = ", ".join(f"{k}: {v:.2f}" for k, v in fi_dict.items()) if fi_dict else "Niet beschikbaar."
+
+    def _safe_value(col: str, cast_fn):
+        if col in vul_set or col not in row.index:
+            return "niet beschikbaar"
+        return cast_fn(row[col])
+
+    analyse = {
+        "naam": naam,
+        "opleiding": row.get("Opleiding", "—"),
+        "klas": row.get("Klas", "—"),
+        "mentor": row.get("Mentor", "—"),
+        "studentnummer": int(row["Studentnummer"]) if "Studentnummer" in row.index else "—",
+        "leeftijd": _safe_value("StudentAge", int),
+        "ongeoorloofd_verzuim": _safe_value("absence_unauthorized", float),
+        "geoorloofd_verzuim": _safe_value("absence_authorized", float),
+        "probability": result["probability"],
+        "explanation": exp,
+        "feature_importance": fi_str,
+        "feature_importance_dict": fi_dict,
+    }
+    analyse["docx"] = _build_word_doc(analyse)
+    st.session_state.laatste_analyse = analyse
+    st.session_state.eduplan_genereren = False
 
 
 # ─────────────────────────────────────────────
@@ -658,7 +692,7 @@ def show_start_screen():
         # ── Upload 1: historische trainingsdata ──
         st.markdown(
             "<p style='font-size:0.9rem; font-weight:600; color:#555; margin-bottom:4px;"
-            "font-family:\"General Sans\",sans-serif;'>Historische data (voor modeltraining)</p>",
+            'font-family:"General Sans",sans-serif;\'>Historische data (voor modeltraining)</p>',
             unsafe_allow_html=True,
         )
         trainings_file = st.file_uploader(
@@ -678,7 +712,7 @@ def show_start_screen():
         # ── Upload 2: huidig cohort ──
         st.markdown(
             "<p style='font-size:0.9rem; font-weight:600; color:#555; margin-bottom:4px;"
-            "font-family:\"General Sans\",sans-serif;'>Huidig cohort (studenten om te ranken)</p>",
+            'font-family:"General Sans",sans-serif;\'>Huidig cohort (studenten om te ranken)</p>',
             unsafe_allow_html=True,
         )
         predictie_file = st.file_uploader(
@@ -1012,14 +1046,14 @@ def _render_eduplan_sectie():
     if st.session_state.eduplan_genereren:
         naam = html.escape(top[st.session_state.geselecteerde_student][0]["Naam"])
         st.markdown(
-            f"""<div style="background:{ROZE_LICHT}; border-radius:14px;
-                            padding:28px; text-align:center; margin-top:16px;
-                            font-family:'General Sans',sans-serif; color:#555;">
-                <span style="font-size:1.4rem;">↻</span>&nbsp;&nbsp;
-                Het EduPlan voor <b>{naam}</b> wordt gemaakt
+            f"""<div style="display:flex; align-items:center; margin-top:16px;
+                            font-family:'General Sans',sans-serif;">
+                <span style="font-size:28px; font-weight:700;">🚦</span>&nbsp;&nbsp;
+                <span style="font-size:2.0rem; font-weight:500;">EduPlan | {naam}</span>
             </div>""",
             unsafe_allow_html=True,
         )
+        # Sectie 1 verschijnt direct, secties 2–4 streamen live binnen deze functie.
         _genereer_eduplan()
         st.rerun()
 

--- a/eduplan/tests/conftest.py
+++ b/eduplan/tests/conftest.py
@@ -38,3 +38,21 @@ def mock_anthropic(monkeypatch) -> MagicMock:
 
     monkeypatch.setattr(main_mod, "client", mock_client)
     return mock_client
+
+
+@pytest.fixture
+def mock_anthropic_stream(monkeypatch) -> MagicMock:
+    """Vervangt de Anthropic-client door een mock met streaming-ondersteuning.
+
+    `client.messages.stream(...)` is een context manager waarvan het object een
+    `text_stream` iterable van tekst-chunks heeft — de vorm die `/explain_risk_stream`
+    gebruikt (anders dan de `messages.create` van de `mock_anthropic`-fixture).
+    """
+    stream_obj = MagicMock()
+    stream_obj.text_stream = ["Gemockte ", "LLM-", "uitvoer"]
+    mock_client = MagicMock()
+    mock_client.messages.stream.return_value.__enter__.return_value = stream_obj
+    import backend.main as main_mod
+
+    monkeypatch.setattr(main_mod, "client", mock_client)
+    return mock_client

--- a/eduplan/tests/test_backend.py
+++ b/eduplan/tests/test_backend.py
@@ -229,6 +229,68 @@ def test_explain_risk_laag_risico(client, demo_student, mock_anthropic):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Endpoint — /explain_risk_stream (NDJSON streaming)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_ndjson(text: str) -> list[dict]:
+    import json
+
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def test_explain_risk_stream_emits_section1_delta_and_final(client, demo_student, mock_anthropic_stream, monkeypatch):
+    """Stream stuurt eerst section1, dan delta's, dan final_html — en roept messages.stream aan."""
+    import numpy as np
+
+    # Forceer informatieve SHAP-waarden zodat het LLM (de stream) wordt aangeroepen
+    mock_exp = MagicMock()
+    shap_array = np.zeros((1, len(main_mod.features)))
+    shap_array[0, 1] = 0.5  # index 1 = StudentAge (index 0 = Studentnummer, uitgesloten)
+    mock_exp.shap_values.return_value = shap_array
+    monkeypatch.setattr(main_mod, "explainer", mock_exp)
+    monkeypatch.setattr(main_mod, "explainer_default", mock_exp)
+
+    payload = {
+        "student": demo_student,
+        "prediction": 1,
+        "probability": 0.70,
+        "imputed_columns": [],
+    }
+    resp = client.post("/explain_risk_stream", json=payload)
+    assert resp.status_code == 200
+
+    berichten = _parse_ndjson(resp.text)
+    soorten = [m["type"] for m in berichten]
+    assert soorten[0] == "section1"
+    assert "HOOG" in berichten[0]["html"]
+    assert "delta" in soorten
+    assert soorten[-1] == "final_html"
+    # De delta's vormen samen de (gemockte) LLM-uitvoer
+    deltas = "".join(m["text"] for m in berichten if m["type"] == "delta")
+    assert deltas == "Gemockte LLM-uitvoer"
+    assert mock_anthropic_stream.messages.stream.called
+
+
+def test_explain_risk_stream_data_onvoldoende_skips_llm(client, demo_student, mock_anthropic_stream):
+    """Bij volledig geïmputeerde data: section1 + warning, geen stream-aanroep."""
+    payload = {
+        "student": demo_student,
+        "prediction": 0,
+        "probability": 0.30,
+        "imputed_columns": features,  # alles geïmputeerd
+    }
+    resp = client.post("/explain_risk_stream", json=payload)
+    assert resp.status_code == 200
+
+    berichten = _parse_ndjson(resp.text)
+    soorten = [m["type"] for m in berichten]
+    assert soorten == ["section1", "warning"]
+    assert "Geen gepersonaliseerd advies" in berichten[1]["html"]
+    assert not mock_anthropic_stream.messages.stream.called
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Endpoints — LLM-afhankelijke endpoints
 # ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Waarom

Bij het opvragen van een EduPlan bleef het scherm ~40s blanco tot één blokkerende LLM-call (max_tokens=2048) klaar was. Dit voelt traag.

## Wat

Sectie 1 (deterministisch risicoprofiel — SHAP = 0.2ms) verschijnt nu **direct**; secties 2–4 streamen **token-voor-token** terwijl het LLM genereert.

| | Oud | Nieuw |
|---|---|---|
| Eerste content | ~40s (blanco) | **~0s** (risicoprofiel) |
| Begeleidingstekst | in één keer aan het eind | **token-voor-token vanaf ~1.3s** |

**Bonus:** de oude `timeout=60` was een *totale* timeout (bij 40s generatie dicht tegen falen); in de streaming-versie is het een *per-chunk* read-gap timeout, dus die latente faalkans is weg.

## Hoe

**Backend (`backend/main.py`)**
- `_prepare_explanation()` deelt de SHAP/Sectie-1/prompt-logica tussen het bestaande `/explain_risk` (onaangetast — fallback + tests) en het nieuwe `/explain_risk_stream`.
- `/explain_risk_stream` → `StreamingResponse` met NDJSON-regels (`section1` / `delta` / `final_html` / `warning`) via `client.messages.stream`.
- markdown→HTML-conversie blijft single source of truth in de backend (`final_html`-regel na de deltas).

**Frontend (`frontend/app.py`)**
- `_genereer_eduplan()` rendert Sectie 1 direct en streamt secties 2–4 via `st.write_stream` op de main thread; feature-importance fetch blijft concurrent in een thread (geen `st.*` erin).

## Tests / verificatie

- 43 tests groen (2 nieuw voor `/explain_risk_stream`); `mock_anthropic_stream`-fixture mockt `messages.stream`. Ruff clean.
- Live tegen de echte Anthropic API: `section1` @0.00s, 96 deltas vanaf 1.31s.
- In de browser: succespad én het "data onvoldoende"-pad renderen netjes (styled card + definitieve render).

Design-doc: `eduplan/docs/superpowers/specs/2026-06-01-eduplan-streaming-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)