### PR TITLE
fix: stream EduPlan-secties 2–4 op witte achtergrond

### DIFF
--- a/eduplan/frontend/app.py
+++ b/eduplan/frontend/app.py
@@ -446,7 +446,7 @@ def _genereer_eduplan():
     # Sectie 1 én de streamende secties 2–4 staan in één witte kaart
     # (.st-key-eduplan-stream-card in MAIN_CSS), zodat de tekst meteen op wit
     # verschijnt i.p.v. op de roze pagina-achtergrond.
-    profiel_ph = None  # st.empty()-slot vóór de streamende tekst (binnen de kaart)
+    profiel_ph = None  # placeholder; echte st.empty()-slot wordt verderop binnen de kaart aangemaakt
     captured = {"section1": None, "final_html": None, "warning": None}
     exp = None
 

--- a/eduplan/frontend/app.py
+++ b/eduplan/frontend/app.py
@@ -442,14 +442,11 @@ def _genereer_eduplan():
     pool = ThreadPoolExecutor(max_workers=1)
     f_fi = pool.submit(_fetch_fi)
 
-    # Styled wrapper die overeenkomt met de definitieve render (_render_eduplan_content).
-    _WRAP = (
-        '<div style=\'font-family:"General Sans",sans-serif; font-size:15px; '
-        "line-height:1.85; background:white; border-radius:16px; padding:28px 32px;'>"
-    )
-
     # ── Stream: Sectie 1 direct, secties 2–4 token-voor-token ─────────────────
-    profiel_ph = st.empty()  # reserveert een slot vóór de streamende tekst
+    # Sectie 1 én de streamende secties 2–4 staan in één witte kaart
+    # (.st-key-eduplan-stream-card in MAIN_CSS), zodat de tekst meteen op wit
+    # verschijnt i.p.v. op de roze pagina-achtergrond.
+    profiel_ph = None  # st.empty()-slot vóór de streamende tekst (binnen de kaart)
     captured = {"section1": None, "final_html": None, "warning": None}
     exp = None
 
@@ -461,7 +458,7 @@ def _genereer_eduplan():
             soort = msg["type"]
             if soort == "section1":
                 captured["section1"] = msg["html"]
-                profiel_ph.markdown(_WRAP + msg["html"] + "</div>", unsafe_allow_html=True)
+                profiel_ph.markdown(msg["html"], unsafe_allow_html=True)
             elif soort == "warning":
                 captured["warning"] = msg["html"]
             elif soort == "delta":
@@ -489,7 +486,9 @@ def _genereer_eduplan():
                 f"Het /explain_risk_stream endpoint gaf een fout terug. Bekijk de backend-log voor details. Response: {snippet}",
             )
         else:
-            st.write_stream(_delta_gen())
+            with st.container(key="eduplan-stream-card"):
+                profiel_ph = st.empty()
+                st.write_stream(_delta_gen())
             if captured["warning"] is not None:
                 exp = (captured["section1"] or "") + captured["warning"]
             elif captured["final_html"] is not None:

--- a/eduplan/frontend/styles.py
+++ b/eduplan/frontend/styles.py
@@ -232,5 +232,18 @@ div.student-sel div[data-testid="stSelectbox"] > div > div[data-baseweb="select"
 }
 [data-testid="stSlider"] div[data-testid="stTickBarMin"],
 [data-testid="stSlider"] div[data-testid="stTickBarMax"] { color: #c8785a !important; }
+
+/* ── EduPlan stream-kaart: witte achtergrond achter sectie 1 én de streamende
+      secties 2–4, zodat de tekst niet op de roze pagina-achtergrond landt ── */
+.st-key-eduplan-stream-card {
+    background: white !important;
+    border-radius: 16px !important;
+    padding: 28px 32px !important;
+    font-family: 'General Sans', sans-serif !important;
+    font-size: 15px !important;
+    line-height: 1.85 !important;
+}
+.st-key-eduplan-stream-card p,
+.st-key-eduplan-stream-card li { line-height: 1.85 !important; }
 </style>
 """


### PR DESCRIPTION
## Probleem

Bij het streamen van het EduPlan landden de begeleidingssecties 2–4 niet op een witte achtergrond, maar op de roze pagina-achtergrond (`#f0d4d4`). Oorzaak: `st.write_stream()` rendert de markdown-tokens als een gewoon Streamlit-element op de pagina, terwijl alleen sectie 1 (het deterministische risicoprofiel) in een witte wrapper-div zat.

## Oplossing

Sectie 1 (`profiel_ph`) én de stream zitten nu samen in één `st.container(key="eduplan-stream-card")`. Een nieuwe CSS-regel `.st-key-eduplan-stream-card` in `MAIN_CSS` geeft die hele kaart een witte achtergrond (`border-radius:16px`, `padding:28px 32px`) plus font/line-height die de finale render benadert, zodat er nauwelijks reflow is bij afronding van de stream. De overbodig geworden `_WRAP`-constante is verwijderd.

Bewust voor de CSS-route gekozen (i.p.v. de markdown in de frontend zelf converteren) om de backend-`_markdown_to_html` niet te dupliceren — past bij de Simplicity/Surgical-richtlijnen.

## Verificatie

Mid-stream in de browser geverifieerd (chrome-devtools):
- Computed style van de streamende kaart: `background-color: rgb(255, 255, 255)`, `border-radius: 16px`, `padding: 28px 32px`
- De streamende secties (Signalen / Interventies / Actiepunten) zitten aantoonbaar ín de witte kaart
- Visueel bevestigd via screenshot
- `ruff check` groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)