### PR TITLE
chore: simplify EduPlan backend/frontend per CEDA review

### DIFF
--- a/eduplan/backend/main.py
+++ b/eduplan/backend/main.py
@@ -108,34 +108,27 @@ def _load_features(path: str) -> list[str]:
         with open(path) as f:
             return json.load(f)
     _NON = set(_cfg["data"]["exclude_columns"]) | {_cfg["data"]["target_column"]}
-    return [c for c in pd.read_csv(_cfg["data"]["path"]).columns if c not in _NON]
+    return [c for c in pd.read_csv(_cfg["data"]["path"], nrows=0).columns if c not in _NON]
 
 
 # Features per model — dynamisch bepaald door student-signal bij training
 features_default = _load_features(MODEL_DEFAULT_FEATURES_PATH)
-features_custom = (
-    _load_features(MODEL_CUSTOM_FEATURES_PATH) if Path(MODEL_CUSTOM_FEATURES_PATH).exists() else features_default
-)
-features = features_custom  # actieve feature-lijst
 
 # Standaardmodel — altijd geladen, gebruikt bij demo-data
 clf_default = joblib.load(MODEL_DEFAULT_PATH)
 explainer_default = shap.TreeExplainer(clf_default)
 
-# Instellingsmodel — geladen indien beschikbaar; anders alias op standaard
+# Actief model — instellingsmodel indien beschikbaar, anders alias op standaard
 if Path(MODEL_CUSTOM_PATH).exists():
-    clf_custom = joblib.load(MODEL_CUSTOM_PATH)
-    explainer_custom = shap.TreeExplainer(clf_custom)
-    imputer_custom = joblib.load(MODEL_CUSTOM_IMPUTER_PATH) if Path(MODEL_CUSTOM_IMPUTER_PATH).exists() else None
+    clf = joblib.load(MODEL_CUSTOM_PATH)
+    explainer = shap.TreeExplainer(clf)
+    imputer = joblib.load(MODEL_CUSTOM_IMPUTER_PATH) if Path(MODEL_CUSTOM_IMPUTER_PATH).exists() else None
+    features = _load_features(MODEL_CUSTOM_FEATURES_PATH)
 else:
-    clf_custom = clf_default
-    explainer_custom = explainer_default
-    imputer_custom = None
-
-# Actief model
-clf = clf_custom
-explainer = explainer_custom
-imputer = imputer_custom
+    clf = clf_default
+    explainer = explainer_default
+    imputer = None
+    features = features_default
 
 
 def _get_model(use_default: bool) -> tuple[RandomForestRegressor, shap.TreeExplainer]:
@@ -165,7 +158,7 @@ _training = _TrainingState()
 
 def _reload_model(path: str | Path) -> None:
     """Laad model, explainer, imputer en features opnieuw en vervang de globale referenties atomisch."""
-    global clf, explainer, imputer, features, features_custom
+    global clf, explainer, imputer, features
     new_clf = joblib.load(path)
     new_explainer = shap.TreeExplainer(new_clf)
     new_features = _load_features(_FEATURES_PATH[str(path)])
@@ -175,7 +168,6 @@ def _reload_model(path: str | Path) -> None:
     explainer = new_explainer
     imputer = new_imputer
     features = new_features
-    features_custom = new_features
 
 
 class StudentData(BaseModel):

--- a/eduplan/frontend/app.py
+++ b/eduplan/frontend/app.py
@@ -70,6 +70,9 @@ def _load_data() -> pd.DataFrame:
 
 NON_FEATURES = {"Dropout", "Naam", "Opleiding", "Klas", "Mentor"}
 
+# Eén plek voor host/poort van de FastAPI-backend (zie ./1_start_fastapi.sh).
+BACKEND_URL = "http://localhost:8000"
+
 
 # ─────────────────────────────────────────────
 # Session state
@@ -142,6 +145,24 @@ def _lees_bestand(uploaded_file) -> pd.DataFrame:
     return pd.read_csv(uploaded_file, sep=None, engine="python")
 
 
+def _map_columns(uploaded_columns: list[str], required_columns: list[str]) -> dict[str, str]:
+    """Vraag de backend om een LLM-koppeling {vereiste_kolom: geüploade_kolom}.
+
+    Degradeert stil naar een lege dict als de backend onbereikbaar is of een fout
+    geeft — auto-mapping is optioneel; ontbrekende kolommen worden daarna alsnog
+    met mediaanwaarden aangevuld.
+    """
+    try:
+        resp = requests.post(
+            f"{BACKEND_URL}/map_columns",
+            json={"uploaded_columns": uploaded_columns, "required_columns": required_columns},
+            timeout=30,
+        )
+        return resp.json().get("mapping", {})
+    except requests.RequestException:
+        return {}
+
+
 def _match_kolommen(
     new_df: pd.DataFrame,
 ) -> tuple[pd.DataFrame, dict[str, str], list[str]]:
@@ -171,19 +192,11 @@ def _match_kolommen(
 
         # LLM-koppeling voor resterende kolommen
         if nog_ontbrekend:
-            try:
-                vrije_kolommen = [c for c in new_df.columns if c not in rename_now]
-                resp = requests.post(
-                    "http://localhost:8000/map_columns",
-                    json={"uploaded_columns": vrije_kolommen, "required_columns": nog_ontbrekend},
-                    timeout=30,
-                )
-                for req, upl in resp.json().get("mapping", {}).items():
-                    if req in nog_ontbrekend and upl in new_df.columns and upl not in rename_now:
-                        rename_now[upl] = req
-                        hernoem_log[upl] = req
-            except Exception:
-                pass
+            vrije_kolommen = [c for c in new_df.columns if c not in rename_now]
+            for req, upl in _map_columns(vrije_kolommen, nog_ontbrekend).items():
+                if req in nog_ontbrekend and upl in new_df.columns and upl not in rename_now:
+                    rename_now[upl] = req
+                    hernoem_log[upl] = req
 
         if rename_now:
             new_df = new_df.rename(columns=rename_now)
@@ -250,17 +263,9 @@ def _verwerk_trainingsdata(uploaded_file) -> None:
                 }
                 _gevonden = next((c for c in new_df.columns if _norm_col(c) in _synoniemen), None)
                 if _gevonden is None:
-                    try:
-                        resp = requests.post(
-                            "http://localhost:8000/map_columns",
-                            json={"uploaded_columns": list(new_df.columns), "required_columns": ["Dropout"]},
-                            timeout=30,
-                        )
-                        _kandidaat = resp.json().get("mapping", {}).get("Dropout")
-                        if _kandidaat and _kandidaat in new_df.columns:
-                            _gevonden = _kandidaat
-                    except Exception:
-                        pass
+                    _kandidaat = _map_columns(list(new_df.columns), ["Dropout"]).get("Dropout")
+                    if _kandidaat and _kandidaat in new_df.columns:
+                        _gevonden = _kandidaat
                 if _gevonden:
                     new_df = new_df.rename(columns={_gevonden: "Dropout"})
 
@@ -367,7 +372,7 @@ def _build_word_doc(analyse: dict) -> BytesIO:
     return bio
 
 
-def _run_voorspelling(dff: pd.DataFrame):
+def _run_voorspelling(dff: pd.DataFrame) -> None:
     """Doe API-call voor alle studenten in dff; sla op in session_state."""
     opl = st.session_state.selected_opleiding
     klas = st.session_state.selected_klas
@@ -384,7 +389,7 @@ def _run_voorspelling(dff: pd.DataFrame):
 
     with st.spinner("Risico berekenen…"):
         resp = requests.post(
-            "http://localhost:8000/rank_students",
+            f"{BACKEND_URL}/rank_students",
             json={
                 "students": dff.to_dict(orient="records"),
                 "use_default_model": gebruik_default,
@@ -397,7 +402,7 @@ def _run_voorspelling(dff: pd.DataFrame):
         st.session_state.top_n = min(len(resultaten), 10)
 
 
-def _genereer_eduplan():
+def _genereer_eduplan() -> None:
     idx = st.session_state.geselecteerde_student
     risico = st.session_state.risicostudenten
     if not risico or idx >= len(risico):
@@ -424,7 +429,7 @@ def _genereer_eduplan():
         # mag het hoofd-EduPlan niet overschaduwen.
         try:
             resp = requests.post(
-                "http://localhost:8000/feature_importance",
+                f"{BACKEND_URL}/feature_importance",
                 json={
                     "student": row.to_dict(),
                     "use_default_model": gebruik_default,
@@ -468,7 +473,7 @@ def _genereer_eduplan():
 
     try:
         resp = requests.post(
-            "http://localhost:8000/explain_risk_stream",
+            f"{BACKEND_URL}/explain_risk_stream",
             json={
                 "student": row.to_dict(),
                 "prediction": result["prediction"],
@@ -506,7 +511,7 @@ def _genereer_eduplan():
     except requests.ConnectionError:
         exp = _error_html(
             "Backend niet bereikbaar",
-            "Geen verbinding met http://localhost:8000. Controleer of de FastAPI backend draait (./1_start_fastapi.sh).",
+            f"Geen verbinding met {BACKEND_URL}. Controleer of de FastAPI backend draait (./1_start_fastapi.sh).",
         )
     except requests.RequestException as e:
         exp = _error_html("Netwerkfout", str(e))
@@ -551,7 +556,7 @@ def _start_training() -> None:
         "dropout_column": "Dropout",
     }
     try:
-        resp = requests.post("http://localhost:8000/train_model", json=payload, timeout=10)
+        resp = requests.post(f"{BACKEND_URL}/train_model", json=payload, timeout=10)
         resultaat = resp.json().get("status")
         if resultaat in ("started", "already_running"):
             st.session_state.training_status = "training"
@@ -562,7 +567,7 @@ def _start_training() -> None:
 
 def _reset_model() -> None:
     try:
-        requests.delete("http://localhost:8000/reset_model", timeout=10)
+        requests.delete(f"{BACKEND_URL}/reset_model", timeout=10)
         st.session_state.training_status = "idle"
         st.session_state.training_message = ""
         st.session_state.model_is_custom = False
@@ -612,7 +617,7 @@ def _show_training_panel() -> None:
 
         # Eén statuscheck per render — geen blokkerende loop
         try:
-            data = requests.get("http://localhost:8000/train_status", timeout=5).json()
+            data = requests.get(f"{BACKEND_URL}/train_status", timeout=5).json()
         except Exception:
             data = {"status": "training"}
 
@@ -657,7 +662,7 @@ def _show_training_panel() -> None:
 # ─────────────────────────────────────────────
 
 
-def show_start_screen():
+def show_start_screen() -> None:
     st.markdown(START_CSS, unsafe_allow_html=True)
     st.markdown("<div style='height:10px'></div>", unsafe_allow_html=True)
 
@@ -794,7 +799,7 @@ def show_start_screen():
 # ─────────────────────────────────────────────
 
 
-def _render_header():
+def _render_header() -> None:
     tab = st.session_state.actieve_tab
 
     col_ceda, col_terug, col_ur, col_ep = st.columns([3, 1.2, 2.2, 1.2])
@@ -832,7 +837,7 @@ def _render_header():
 # ─────────────────────────────────────────────
 
 
-def _render_card_header():
+def _render_card_header() -> None:
     opl = st.session_state.selected_opleiding
 
     if st.session_state.toon_zoekbalk:
@@ -908,7 +913,7 @@ def _render_card_header():
 # ─────────────────────────────────────────────
 
 
-def _render_banner():
+def _render_banner() -> None:
     risico = st.session_state.risicostudenten
 
     label = f"<u><b>{st.session_state.top_n}</b></u>" if risico else "···"
@@ -943,7 +948,7 @@ def _render_banner():
 # ─────────────────────────────────────────────
 
 
-def _render_barchart():
+def _render_barchart() -> None:
     risico = st.session_state.risicostudenten
 
     if not risico:
@@ -1003,7 +1008,7 @@ def _render_barchart():
 # ─────────────────────────────────────────────
 
 
-def _render_eduplan_sectie():
+def _render_eduplan_sectie() -> None:
     risico = st.session_state.risicostudenten
     top_n = st.session_state.top_n
 
@@ -1060,7 +1065,7 @@ def _render_eduplan_sectie():
         _render_eduplan_content()
 
 
-def _render_eduplan_content():
+def _render_eduplan_content() -> None:
     analyse = st.session_state.laatste_analyse
     naam = html.escape(analyse["naam"])
 
@@ -1108,7 +1113,7 @@ def _render_eduplan_content():
 # ─────────────────────────────────────────────
 
 
-def _render_footer():
+def _render_footer() -> None:
     st.markdown("<div style='height:32px'></div>", unsafe_allow_html=True)
     st.markdown(
         """<hr style="border:none; border-top:2px solid rgba(0,0,0,0.32); margin:0 0 20px 0;">
@@ -1127,7 +1132,7 @@ def _render_footer():
 # ─────────────────────────────────────────────
 
 
-def show_main_screen():
+def show_main_screen() -> None:
     st.markdown(MAIN_CSS, unsafe_allow_html=True)
 
     _render_header()


### PR DESCRIPTION
## Doel

Veilige opschoning van de EduPlan-codebase op basis van een `/simplify-ceda` review (drie agents: reuse / quality / efficiency). Alleen gedragsbehoudende fixes — geen functionele wijzigingen.

## Wijzigingen

| Bevinding | Fix |
|-----------|-----|
| Backend-URL 8× hardcoded (+1 in foutmelding) in de frontend | Eén `BACKEND_URL`-constante + f-strings op alle call-sites |
| Dubbele `/map_columns`-POST + bare `except Exception` | `_map_columns()`-helper; except genarrowd naar `requests.RequestException` |
| 11 render-functies misten `-> None` | Batch toegevoegd (consistent met siblings) |
| Dode redundante `_custom`-modelglobals; `features_custom`-herassignment in `_reload_model` werd nergens gelezen | Init laadt direct in de actieve globals; dode regel + global verwijderd |
| `_load_features`-fallback las de hele CSV voor enkel kolomnamen | `pd.read_csv(..., nrows=0)` |

## Bewust níét in deze PR (genoteerd als follow-up)

Grotere/gedragsveranderende items die aparte verificatie vragen:
- SHAP wordt 2× berekend per EduPlan (`/feature_importance` + `/explain_risk_stream`) — vereist wijziging aan het streaming-protocol.
- Upload-handlers delen een skelet — callback-refactor met regressierisico op de upload-flow.
- Diepe nesting in `_match_kolommen` (inherent aan de structuur).

## Verificatie

- `uv run pytest tests/` → **43/43 groen**
- `uv run ruff check` / `format` → schoon
- Beide modules compileren (`py_compile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)